### PR TITLE
update condensed creativity log

### DIFF
--- a/src/modules/better-journal/styles/fullstop.css
+++ b/src/modules/better-journal/styles/fullstop.css
@@ -42,7 +42,6 @@
 .entry.halloween_boiling_cauldron.brew_finished a:last-of-type::after,
 .entry.halloween_boiling_cauldron.brew_removed a:last-of-type::after,
 .entry.badge .journaltext a::after,
-.entry.folkloreForest.folkloreForest-lootFuelBoost .journaltext::after,
 .entry.folkloreForest-farmToTable .journaltext a:last-of-type::after,
 .entry.folkloreForest-forewordFarm.folkloreForest-plantStarted .journaltext a::after,
 .entry.festiveSpiritLootBoost .journaltext a::after,


### PR DESCRIPTION
remove extra dot at the end of a condensed creativity log.

Before:
![image](https://github.com/MHCommunity/mousehunt-improved/assets/3811554/f151a649-f1d6-4fe1-9c2f-1504490bb910)

After:
![image](https://github.com/MHCommunity/mousehunt-improved/assets/3811554/d0ce2211-74d0-4e11-86a4-f244f36151ad)
