### PR TITLE
Add Umbra run state to location dashboard

### DIFF
--- a/src/modules/location-dashboard/location/rift-valour.js
+++ b/src/modules/location-dashboard/location/rift-valour.js
@@ -19,11 +19,12 @@ export default (quests) => {
     speed: quests?.QuestRiftValour?.power_up_data?.long_stride?.current_level + 1 || 1,
     sync: quests?.QuestRiftValour?.power_up_data?.hunt_limit?.current_level + 1 || 1,
     siphon: quests?.QuestRiftValour?.power_up_data?.boss_extension?.current_level + 1 || 1,
+    umbra: quests?.QuestRiftValour?.augmentation_data?.tu?.is_locked === null ? 'Ultimate Umbra Run' : 'Normal Run',
   };
 
   let text = '';
 
   text = quest.floor === 0 ? 'Outside' : `Floor ${quest.floor} (${quest.floor_name}) ${quest.hunts_remaining} hunts remaining`;
 
-  return `${text} <div class="stats">Speed ${quest.speed} · Sync ${quest.sync} · Siphon ${quest.siphon}</div>`;
+  return `${quest.umbra}</br> ${text} <div class="stats">Speed ${quest.speed} · Sync ${quest.sync} · Siphon ${quest.siphon}</div>`;
 };

--- a/src/modules/location-dashboard/location/rift-valour.js
+++ b/src/modules/location-dashboard/location/rift-valour.js
@@ -26,5 +26,5 @@ export default (quests) => {
 
   text = quest.floor === 0 ? 'Outside' : `Floor ${quest.floor} (${quest.floor_name}) ${quest.hunts_remaining} hunts remaining`;
 
-  return `${quest.umbra}</br> ${text} <div class="stats">Speed ${quest.speed} · Sync ${quest.sync} · Siphon ${quest.siphon}</div>`;
+  return `<div>${quest.umbra}</div> ${text} <div class="stats">Speed ${quest.speed} · Sync ${quest.sync} · Siphon ${quest.siphon}</div>`;
 };


### PR DESCRIPTION
The 'rift-valour.js' module has been updated to include 'Umbra' run state information to the quest details in the location module.

![image](https://github.com/MHCommunity/mousehunt-improved/assets/3811554/e4933fb4-adf3-4c75-8e6c-3788dc0f53da)
