### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force Git to checkout text files as LF for ESLint conformity
+* text eol=lf
+
+# Git thinks PNG files are a good candidate for CRLF replacement. They aren't.
+*.png binary


### PR DESCRIPTION
Add a .gitattributes file to normalize line endings to `LF` on all platforms.

Since Git on Windows defaults to `core.autocrlf` to `true`, it will checkout line endings as `CRLF`. This conflicts with the ESLint rule `"linebreak-style": ["error", "unix"],` to create thousands of nice little errors for linting.  

The gitattributes file added will make all text files (as detected by git), checkout and checkin with `LF` line endings. Git also thinks `.png` are text files. Cool! Turn them back into binary files by specifying it as such.