### PR TITLE
Release/41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 - Updated styles
 
+### Better Inventory
+
+- Added cap of 200 items being opened at once
+
 ### Better Journal
 
 - Refactored journal processing for more stablility
@@ -30,9 +34,9 @@
 - Added ability to drag sticky mouse details popup out of map and keep it open
 - Updated styles
 
-- ### Better Send Supplies
--
-- - Updated styles
+### Better Send Supplies
+
+- Updated styles
 
 ### Better Shops
 
@@ -59,6 +63,10 @@
 - Big Timer - Updated styles for Legacy HUD
 - Journal Tags - Updated styles
 - favicons
+
+### Inventory Open all but One
+
+- Added cap of 200 items being opened at once
 
 ### Location Dashboard
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Updated scroll shop tab to be easier to navigate
 - Added ability to drag sticky mouse details popup out of map and keep it open
 - Updated styles
+- Updated 'Show goals in sidebar' setting to default to disabled
 
 ### Better Send Supplies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ### Better Shops
 
-- Added "Limit 1" to items that have an inventory limit	Updated styles
+- Added "Limit 1" to items that have an inventory limit
 
 ### Better Travel
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,110 @@
 # Changelog
 
+## Version 0.41.0
+
+### New Features
+
+- Added "Delayed Menus" experiment to delay the opening of menus
+- Added "Legacy HUD Tweaks" experiment to tweak the Legacy HUD
+- Added "Legacy HUD" experiment to enable either part or all of the Legacy HUD
+- Added "Shield Goes to Camp" experiment which will update the shield to link to the camp unless you're already there
+- Added "Sticky Popups" experiment to make popups/overlays sticky
+- Added "Unique Loot Count" experiment to show the total and unique loot counts in your progress log
+
+### Better Gifts
+
+- Updated styles
+
+### Better Journal
+
+- Refactored journal processing for more stablility
+- Fixed image duplication when viewing historical mouse catch entries
+- Updated replacements
+- Added new crown journal entry styles
+- Update styles
+
+### Better Maps
+
+- Fixed issue with "Default to Sorted tab" not working
+- Updated scroll shop tab to be easier to navigate
+- Added ability to drag sticky mouse details popup out of map and keep it open
+- Updated styles
+
+- ### Better Send Supplies
+-
+- - Updated styles
+
+### Better Shops
+
+- Added "Limit 1" to items that have an inventory limit	Updated styles
+
+### Better Travel
+
+- Fixed favorite buttons not showing
+- Updated styles
+
+### Better UI
+
+- Added `no-kingdom-link-replacement` feature flag to disable kingdom link replacement
+- Updated styles
+
+### Experiments
+
+- Added "Delayed Menus" experiment to delay the opening of menus
+- Added "Legacy HUD Tweaks" experiment to tweak the Legacy HUD
+- Added "Legacy HUD" experiment to enable either part or all of the Legacy HUD
+- already there    Added "Sticky Popups" experiment to make popups/overlays sticky
+- Added "Unique Loot Count" experiment to show the total and unique loot counts in your progress log
+- Big Timer - Fixed issue with timer not showing
+- Big Timer - Updated styles for Legacy HUD
+- Journal Tags - Updated styles
+- favicons
+
+### Location Dashboard
+
+- Added ability to click on the location name to travel to the location
+- Updates Bountiful Beanstalk display
+- Updates Fiery Warpath display
+- Updates Floating Islands display
+
+### Location HUDs: Bountiful Beanstalk
+
+- Removes room loot title change
+- Updates crafting button amounts
+- Updates styles
+
+### Location HUDs: Fiery Warpath
+
+- Fixed easter egg activation position and streak container styling
+
+### Location HUDs: Floating Islands
+
+- Style updates
+
+### Location HUDs: Spring Egg Hunt
+
+- Add ability to right-click on tile while playing Eggsweeper to mark with a flag
+- Updated styles
+
+### Quick Send Supplies
+
+- Added seperator in options for clarity
+- Updated styles
+
+### Show Auras
+
+- Updated styles
+
+### Taller Windows
+
+- Updated Airship customizer window to be full height
+- Updated styles
+
+### Other
+
+- Updates error page styles
+- Performance improvements and minor bug fixes
+
 ## Version 0.40.4
 
 - Fixes Send Supplies width

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -10,6 +10,7 @@ Add any of the following flags, comma-separated, to the feature flags option to 
 |---|---|
 |`social-noop`|Replaces `hg.classes.SocialLink` and `twttr` objects with noops.|
 |`no-onboarding`|Disables the MouseHunt Improved tutorial from Larry.|
+|`no-kingdom-link-replacement`|Makes the Kingdom link to go the forums, rather than the News page.|
 
 The [debug logging](./debug-logging.md) module also is configured using feature flags.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mh-ui",
-  "version": "0.40.4",
+  "version": "0.41.0",
   "description": "Improve your MouseHunt experience.",
   "author": "Brad Parbs <brad@bradparbs.com> (https://bradparbs.com/)",
   "license": "MIT",

--- a/scripts/release
+++ b/scripts/release
@@ -19,3 +19,5 @@ bun run build:zips
 bun run build:userscript
 
 bun run build:archive
+
+gh release create "v$version" --title "MouseHunt Improved $version" --draft dist/chrome.zip dist/firefox.zip dist/*.user.js

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -36,270 +36,58 @@
     "ultimate-checkmark.show"
   ],
   "icons": [
-    {
-      "category": "better",
-      "id": "better-ui",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-gifts",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-inventory",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-item-view",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-journal",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-kings-reward",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-maps",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z' /><path stroke-linecap='round' stroke-linejoin='round' d='M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-marketplace",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-mice",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='m9 14.25 6-6m4.5-3.493V21.75l-3.75-1.5-3.75 1.5-3.75-1.5-3.75 1.5V4.757c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0c1.1.128 1.907 1.077 1.907 2.185ZM9.75 9h.008v.008H9.75V9Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm4.125 4.5h.008v.008h-.008V13.5Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-quests",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M10.125 2.25h-4.5c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125v-9M10.125 2.25h.375a9 9 0 0 1 9 9v.375M10.125 2.25A3.375 3.375 0 0 1 13.5 5.625v1.5c0 .621.504 1.125 1.125 1.125h1.5a3.375 3.375 0 0 1 3.375 3.375M9 15l2.25 2.25L15 12' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-send-supplies",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 0 1-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.213-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-shops",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M13.5 21v-7.5a.75.75 0 0 1 .75-.75h3a.75.75 0 0 1 .75.75V21m-4.5 0H2.36m11.14 0H18m0 0h3.64m-1.39 0V9.349M3.75 21V9.349m0 0a3.001 3.001 0 0 0 3.75-.615A2.993 2.993 0 0 0 9.75 9.75c.896 0 1.7-.393 2.25-1.016a2.993 2.993 0 0 0 2.25 1.016c.896 0 1.7-.393 2.25-1.015a3.001 3.001 0 0 0 3.75.614m-16.5 0a3.004 3.004 0 0 1-.621-4.72l1.189-1.19A1.5 1.5 0 0 1 5.378 3h13.243a1.5 1.5 0 0 1 1.06.44l1.19 1.189a3 3 0 0 1-.621 4.72M6.75 18h3.75a.75.75 0 0 0 .75-.75V13.5a.75.75 0 0 0-.75-.75H6.75a.75.75 0 0 0-.75.75v3.75c0 .414.336.75.75.75Z' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-tournaments",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 0 1-.982-3.172M9.497 14.25a7.454 7.454 0 0 0 .981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 0 0 7.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 0 0 2.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 0 1 2.916.52 6.003 6.003 0 0 1-5.395 4.972m0 0a6.726 6.726 0 0 1-2.749 1.35m0 0a6.772 6.772 0 0 1-3.044 0' /></svg>"
-    },
-    {
-      "category": "better",
-      "id": "better-travel",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "catch-rate-estimate",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M15.75 15.75V18m-7.5-6.75h.008v.008H8.25v-.008Zm0 2.25h.008v.008H8.25V13.5Zm0 2.25h.008v.008H8.25v-.008Zm0 2.25h.008v.008H8.25V18Zm2.498-6.75h.007v.008h-.007v-.008Zm0 2.25h.007v.008h-.007V13.5Zm0 2.25h.007v.008h-.007v-.008Zm0 2.25h.007v.008h-.007V18Zm2.504-6.75h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V13.5Zm0 2.25h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V18Zm2.498-6.75h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V13.5ZM8.25 6h7.5v2.25h-7.5V6ZM12 2.25c-1.892 0-3.758.11-5.593.322C5.307 2.7 4.5 3.65 4.5 4.757V19.5a2.25 2.25 0 0 0 2.25 2.25h10.5a2.25 2.25 0 0 0 2.25-2.25V4.757c0-1.108-.806-2.057-1.907-2.185A48.507 48.507 0 0 0 12 2.25Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "copy-id",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M8.25 7.5V6.108c0-1.135.845-2.098 1.976-2.192.373-.03.748-.057 1.123-.08M15.75 18H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08M15.75 18.75v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5A3.375 3.375 0 0 0 6.375 7.5H5.25m11.9-3.664A2.251 2.251 0 0 0 15 2.25h-1.5a2.251 2.251 0 0 0-2.15 1.586m5.8 0c.065.21.1.433.1.664v.75h-6V4.5c0-.231.035-.454.1-.664M6.75 7.5H4.875c-.621 0-1.125.504-1.125 1.125v12c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V16.5a9 9 0 0 0-9-9Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "dark-mode",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "data-exporters",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "delayed-tooltips",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M15.042 21.672 13.684 16.6m0 0-2.51 2.225.569-9.47 5.227 7.917-3.286-.672ZM12 2.25V4.5m5.834.166-1.591 1.591M20.25 10.5H18M7.757 14.743l-1.59 1.59M6 10.5H3.75m4.007-4.243-1.59-1.59' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "favorite-setups",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "fixes",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M21.75 6.75a4.5 4.5 0 0 1-4.884 4.484c-1.076-.091-2.264.071-2.95.904l-7.152 8.684a2.548 2.548 0 1 1-3.586-3.586l8.684-7.152c.833-.686.995-1.874.904-2.95a4.5 4.5 0 0 1 6.336-4.486l-3.276 3.276a3.004 3.004 0 0 0 2.25 2.25l3.276-3.276c.256.565.398 1.192.398 1.852Z' /><path stroke-linecap='round' stroke-linejoin='round' d='M4.867 19.125h.008v.008h-.008v-.008Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "flrt-helper",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M8.25 9.75h4.875a2.625 2.625 0 0 1 0 5.25H12M8.25 9.75 10.5 7.5M8.25 9.75 10.5 12m9-7.243V21.75l-3.75-1.5-3.75 1.5-3.75-1.5-3.75 1.5V4.757c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0c1.1.128 1.907 1.077 1.907 2.185Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "hover-profiles",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M15.042 21.672 13.684 16.6m0 0-2.51 2.225.569-9.47 5.227 7.917-3.286-.672Zm-7.518-.267A8.25 8.25 0 1 1 20.25 10.5M8.288 14.212A5.25 5.25 0 1 1 17.25 10.5' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "image-upscaling",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "inline-wiki",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M4.26 10.147a60.438 60.438 0 0 0-.491 6.347A48.62 48.62 0 0 1 12 20.904a48.62 48.62 0 0 1 8.232-4.41 60.46 60.46 0 0 0-.491-6.347m-15.482 0a50.636 50.636 0 0 0-2.658-.813A59.906 59.906 0 0 1 12 3.493a59.903 59.903 0 0 1 10.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0 1 12 13.489a50.702 50.702 0 0 1 7.74-3.342M6.75 15a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 0v-3.675A55.378 55.378 0 0 1 12 8.443m-7.007 11.55A5.981 5.981 0 0 0 6.75 15.75v-1.5' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "inventory-lock-and-hide",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "journal-changer",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "keyboard-shortcuts",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-2 -5 24 24' width='28' fill='currentColor'><path d='M3 0h14a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H3a3 3 0 0 1-3-3V3a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H3zm0 4h2v2H3V6zm0-3h2v2H3V3zm0 6h2v2H3V9zm3 0h8v2H6V9zm0-3h2v2H6V6zm0-3h2v2H6V3zm3 3h2v2H9V6zm0-3h2v2H9V3zm6 6h2v2h-2V9zm-3-3h2v2h-2V6zm0-3h2v2h-2V3zm3 0h2v5h-2V3z'></path></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "larger-codices",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 24 24' width='28' fill='currentColor'><path d='M12.586 2H11a1 1 0 0 1 0-2h4a1 1 0 0 1 1 1v4a1 1 0 0 1-2 0V3.414L9.414 8 14 12.586V11a1 1 0 0 1 2 0v4a1 1 0 0 1-1 1h-4a1 1 0 0 1 0-2h1.586L8 9.414 3.414 14H5a1 1 0 0 1 0 2H1a1 1 0 0 1-1-1v-4a1 1 0 0 1 2 0v1.586L6.586 8 2 3.414V5a1 1 0 1 1-2 0V1a1 1 0 0 1 1-1h4a1 1 0 1 1 0 2H3.414L8 6.586 12.586 2z'></path></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "larger-skin-images",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "lgs-reminder",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "location-catch-stats",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "location-dashboard",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "metric",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "only-open-multiple",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "open-all-but-one",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M16.5 8.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v8.25A2.25 2.25 0 0 0 6 16.5h2.25m8.25-8.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-7.5A2.25 2.25 0 0 1 8.25 18v-1.5m8.25-8.25h-6a2.25 2.25 0 0 0-2.25 2.25v6' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "paste-hunter-id",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336a6.721 6.721 0 0 1-3.17.789 6.721 6.721 0 0 1-3.168-.789 3.376 3.376 0 0 1 6.338 0Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "prestige-base-stats",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-5 -4 24 24' width='28' fill='currentColor'><path d='M1 0a1 1 0 0 1 1 1v14a1 1 0 0 1-2 0V1a1 1 0 0 1 1-1zm12 4a1 1 0 0 1 1 1v10a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zM7 8a1 1 0 0 1 1 1v6a1 1 0 0 1-2 0V9a1 1 0 0 1 1-1z'></path></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "printing-press-paper-counter",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -2 24 24' width='28' fill='currentColor'><path d='M10.298 2H3a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V4.961L10.298 2zM3 0h8l5 4v13a3 3 0 0 1-3 3H3a3 3 0 0 1-3-3V3a3 3 0 0 1 3-3z'></path></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "quick-filters-and-sort",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "quick-send-supplies",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "ssdb-teeth-counter",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M21 10.5h.375c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125H21M4.5 10.5h6.75V15H4.5v-4.5ZM3.75 18h15A2.25 2.25 0 0 0 21 15.75v-6a2.25 2.25 0 0 0-2.25-2.25h-15A2.25 2.25 0 0 0 1.5 9.75v6A2.25 2.25 0 0 0 3.75 18Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "taller-windows",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M3 8.25V18a2.25 2.25 0 0 0 2.25 2.25h13.5A2.25 2.25 0 0 0 21 18V8.25m-18 0V6a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 6v2.25m-18 0h18M5.25 6h.008v.008H5.25V6ZM7.5 6h.008v.008H7.5V6Zm2.25 0h.008v.008H9.75V6Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "tem-crowns",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "ultimate-checkmark-show",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "wisdom-in-stat-bar",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M4.26 10.147a60.438 60.438 0 0 0-.491 6.347A48.62 48.62 0 0 1 12 20.904a48.62 48.62 0 0 1 8.232-4.41 60.46 60.46 0 0 0-.491-6.347m-15.482 0a50.636 50.636 0 0 0-2.658-.813A59.906 59.906 0 0 1 12 3.493a59.903 59.903 0 0 1 10.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0 1 12 13.489a50.702 50.702 0 0 1 7.74-3.342M6.75 15a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 0v-3.675A55.378 55.378 0 0 1 12 8.443m-7.007 11.55A5.981 5.981 0 0 0 6.75 15.75v-1.5' /></svg>"
-    },
-    {
-      "category": "design",
-      "id": "custom-background",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M4.098 19.902a3.75 3.75 0 0 0 5.304 0l6.401-6.402M6.75 21A3.75 3.75 0 0 1 3 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 0 0 3.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008Z' /></svg>"
-    },
-    {
-      "category": "design",
-      "id": "custom-horn",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46' /></svg>"
-    },
-    {
-      "category": "design",
-      "id": "custom-hud",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M9.53 16.122a3 3 0 0 0-5.78 1.128 2.25 2.25 0 0 1-2.4 2.245 4.5 4.5 0 0 0 8.4-2.245c0-.399-.078-.78-.22-1.128Zm0 0a15.998 15.998 0 0 0 3.388-1.62m-5.043-.025a15.994 15.994 0 0 1 1.622-3.395m3.42 3.42a15.995 15.995 0 0 0 4.764-4.648l3.876-5.814a1.151 1.151 0 0 0-1.597-1.597L14.146 6.32a15.996 15.996 0 0 0-4.649 4.763m3.42 3.42a6.776 6.776 0 0 0-3.42-3.42' /></svg>"
-    },
-    {
-      "category": "design",
-      "id": "custom-shield",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z' /></svg>"
-    },
-    {
-      "category": "beta",
-      "id": "experiments",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5' /></svg>"
-    },
-    {
-      "category": "beta",
-      "id": "show-auras",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z' /></svg>"
-    },
-    {
-      "category": "feature",
-      "id": "profile-scoreboard-search",
-      "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -1 24 24' width='28' fill='currentColor'><path d='M4 14.517l-.612-1.258a1 1 0 0 0-.43-.447l-2-1.06a1 1 0 0 1-.485-1.181l.71-2.273a1 1 0 0 0 0-.596l-.71-2.273a1 1 0 0 1 .486-1.182l1.999-1.06a1 1 0 0 0 .43-.446L4.393.674A1 1 0 0 1 5.615.165l2.062.703a1 1 0 0 0 .646 0l2.062-.703a1 1 0 0 1 1.222.51l1.005 2.066a1 1 0 0 0 .43.447l2 1.06a1 1 0 0 1 .485 1.181l-.71 2.273a1 1 0 0 0 0 .596l.71 2.273a1 1 0 0 1-.486 1.182l-1.999 1.06a1 1 0 0 0-.43.446L12 14.517v6.879l-4-1.358-4 1.358v-6.88zm2 1.187v2.9l2-.679 2 .68v-2.901l-1.677-.572a1 1 0 0 0-.646 0L6 15.704zm4.813-3.32a3 3 0 0 1 1.293-1.339l1.264-.67-.462-1.48a3 3 0 0 1 0-1.79l.462-1.48-1.264-.67a3 3 0 0 1-1.293-1.34l-.619-1.272-1.226.418a3 3 0 0 1-1.936 0l-1.226-.418-.619 1.273a3 3 0 0 1-1.293 1.339l-1.264.67.462 1.48a3 3 0 0 1 0 1.79l-.462 1.48 1.264.67a3 3 0 0 1 1.293 1.34l.619 1.272 1.226-.418a3 3 0 0 1 1.936 0l1.226.418.619-1.273zM8 5a1 1 0 0 1 1 1v4a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z'></path></svg>')"
-    }
+    {"category": "better", "id": "better-gifts", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z' /></svg>" },
+    {"category": "better", "id": "better-inventory", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9' /></svg>" },
+    {"category": "better", "id": "better-item-view", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z' /></svg>" },
+    {"category": "better", "id": "better-journal", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25' /></svg>" },
+    {"category": "better", "id": "better-kings-reward", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-2 -4 24 24' width='28' fill='currentColor'><path d='M2.776 5.106L3.648 11h12.736l.867-5.98-3.493 3.02-3.755-4.827-3.909 4.811-3.318-2.918zm10.038-1.537l-.078.067.141.014 1.167 1.499 1.437-1.242.14.014-.062-.082 2.413-2.086a1 1 0 0 1 1.643.9L18.115 13H1.922L.399 2.7a1 1 0 0 1 1.65-.898L4.35 3.827l-.05.06.109-.008 1.444 1.27 1.212-1.493.109-.009-.06-.052L9.245.976a1 1 0 0 1 1.565.017l2.005 2.576zM2 14h16v1a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-1z'></path></svg>" },
+    {"category": "better", "id": "better-maps", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-2 -2 24 24' width='28' fill='currentColor'><path d='M2 17.613l3.419-1.14A5 5 0 0 1 6 16.317V2.387L2 3.721v13.892zm-.662 2.328A1 1 0 0 1 0 19V3a1 1 0 0 1 .706-.956L5.419.473a5 5 0 0 1 3.162 0l3.47 1.157a3 3 0 0 0 1.898 0L18.662.059A1 1 0 0 1 20 1v16a1 1 0 0 1-.706.956l-4.713 1.571a5 5 0 0 1-3.162 0l-3.47-1.157a3 3 0 0 0-1.898 0l-4.713 1.571zM18 16.28V2.387l-3.419 1.14a5 5 0 0 1-.581.156v13.93l4-1.334zm-6 1.334V3.683a5 5 0 0 1-.581-.156L8 2.387v13.93a5 5 0 0 1 .581.156L12 17.613z'></path></svg>" },
+    {"category": "better", "id": "better-marketplace", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z' /></svg>" },
+    {"category": "better", "id": "better-mice", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='m9 14.25 6-6m4.5-3.493V21.75l-3.75-1.5-3.75 1.5-3.75-1.5-3.75 1.5V4.757c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0c1.1.128 1.907 1.077 1.907 2.185ZM9.75 9h.008v.008H9.75V9Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm4.125 4.5h.008v.008h-.008V13.5Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z' /></svg>" },
+    {"category": "better", "id": "better-quests", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M10.125 2.25h-4.5c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125v-9M10.125 2.25h.375a9 9 0 0 1 9 9v.375M10.125 2.25A3.375 3.375 0 0 1 13.5 5.625v1.5c0 .621.504 1.125 1.125 1.125h1.5a3.375 3.375 0 0 1 3.375 3.375M9 15l2.25 2.25L15 12' /></svg>" },
+    {"category": "better", "id": "better-send-supplies", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 0 1-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.213-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12' /></svg>" },
+    {"category": "better", "id": "better-shops", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M13.5 21v-7.5a.75.75 0 0 1 .75-.75h3a.75.75 0 0 1 .75.75V21m-4.5 0H2.36m11.14 0H18m0 0h3.64m-1.39 0V9.349M3.75 21V9.349m0 0a3.001 3.001 0 0 0 3.75-.615A2.993 2.993 0 0 0 9.75 9.75c.896 0 1.7-.393 2.25-1.016a2.993 2.993 0 0 0 2.25 1.016c.896 0 1.7-.393 2.25-1.015a3.001 3.001 0 0 0 3.75.614m-16.5 0a3.004 3.004 0 0 1-.621-4.72l1.189-1.19A1.5 1.5 0 0 1 5.378 3h13.243a1.5 1.5 0 0 1 1.06.44l1.19 1.189a3 3 0 0 1-.621 4.72M6.75 18h3.75a.75.75 0 0 0 .75-.75V13.5a.75.75 0 0 0-.75-.75H6.75a.75.75 0 0 0-.75.75v3.75c0 .414.336.75.75.75Z' /></svg>" },
+    {"category": "better", "id": "better-tournaments", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 0 1-.982-3.172M9.497 14.25a7.454 7.454 0 0 0 .981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 0 0 7.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 0 0 2.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 0 1 2.916.52 6.003 6.003 0 0 1-5.395 4.972m0 0a6.726 6.726 0 0 1-2.749 1.35m0 0a6.772 6.772 0 0 1-3.044 0' /></svg>" },
+    {"category": "better", "id": "better-travel", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-5 -2 24 24' width='28' fill='currentColor'><path d='M12 7A5 5 0 1 0 2 7c0 1.726 1.66 5.031 5 9.653 3.34-4.622 5-7.927 5-9.653zM7 20C2.333 13.91 0 9.577 0 7a7 7 0 1 1 14 0c0 2.577-2.333 6.91-7 13zm0-9a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z'></path></svg>" },
+    {"category": "better", "id": "better-ui", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z' /></svg>" },
+    {"category": "design", "id": "custom-background", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M4.098 19.902a3.75 3.75 0 0 0 5.304 0l6.401-6.402M6.75 21A3.75 3.75 0 0 1 3 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 0 0 3.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008Z' /></svg>" },
+    {"category": "design", "id": "custom-horn", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46' /></svg>" },
+    {"category": "design", "id": "custom-hud", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M9.53 16.122a3 3 0 0 0-5.78 1.128 2.25 2.25 0 0 1-2.4 2.245 4.5 4.5 0 0 0 8.4-2.245c0-.399-.078-.78-.22-1.128Zm0 0a15.998 15.998 0 0 0 3.388-1.62m-5.043-.025a15.994 15.994 0 0 1 1.622-3.395m3.42 3.42a15.995 15.995 0 0 0 4.764-4.648l3.876-5.814a1.151 1.151 0 0 0-1.597-1.597L14.146 6.32a15.996 15.996 0 0 0-4.649 4.763m3.42 3.42a6.776 6.776 0 0 0-3.42-3.42' /></svg>" },
+    {"category": "design", "id": "custom-shield", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z' /></svg>" },
+    {"category": "feature", "id": "catch-rate-estimate", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M15.75 15.75V18m-7.5-6.75h.008v.008H8.25v-.008Zm0 2.25h.008v.008H8.25V13.5Zm0 2.25h.008v.008H8.25v-.008Zm0 2.25h.008v.008H8.25V18Zm2.498-6.75h.007v.008h-.007v-.008Zm0 2.25h.007v.008h-.007V13.5Zm0 2.25h.007v.008h-.007v-.008Zm0 2.25h.007v.008h-.007V18Zm2.504-6.75h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V13.5Zm0 2.25h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V18Zm2.498-6.75h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V13.5ZM8.25 6h7.5v2.25h-7.5V6ZM12 2.25c-1.892 0-3.758.11-5.593.322C5.307 2.7 4.5 3.65 4.5 4.757V19.5a2.25 2.25 0 0 0 2.25 2.25h10.5a2.25 2.25 0 0 0 2.25-2.25V4.757c0-1.108-.806-2.057-1.907-2.185A48.507 48.507 0 0 0 12 2.25Z' /></svg>" },
+    {"category": "feature", "id": "copy-id", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M8.25 7.5V6.108c0-1.135.845-2.098 1.976-2.192.373-.03.748-.057 1.123-.08M15.75 18H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08M15.75 18.75v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5A3.375 3.375 0 0 0 6.375 7.5H5.25m11.9-3.664A2.251 2.251 0 0 0 15 2.25h-1.5a2.251 2.251 0 0 0-2.15 1.586m5.8 0c.065.21.1.433.1.664v.75h-6V4.5c0-.231.035-.454.1-.664M6.75 7.5H4.875c-.621 0-1.125.504-1.125 1.125v12c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V16.5a9 9 0 0 0-9-9Z' /></svg>" },
+    {"category": "feature", "id": "dark-mode", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z' /></svg>" },
+    {"category": "feature", "id": "data-exporters", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125' /></svg>" },
+    {"category": "feature", "id": "delayed-tooltips", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M15.042 21.672 13.684 16.6m0 0-2.51 2.225.569-9.47 5.227 7.917-3.286-.672ZM12 2.25V4.5m5.834.166-1.591 1.591M20.25 10.5H18M7.757 14.743l-1.59 1.59M6 10.5H3.75m4.007-4.243-1.59-1.59' /></svg>" },
+    {"category": "feature", "id": "favorite-setups", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z' /></svg>" },
+    {"category": "feature", "id": "fixes", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M21.75 6.75a4.5 4.5 0 0 1-4.884 4.484c-1.076-.091-2.264.071-2.95.904l-7.152 8.684a2.548 2.548 0 1 1-3.586-3.586l8.684-7.152c.833-.686.995-1.874.904-2.95a4.5 4.5 0 0 1 6.336-4.486l-3.276 3.276a3.004 3.004 0 0 0 2.25 2.25l3.276-3.276c.256.565.398 1.192.398 1.852Z' /><path stroke-linecap='round' stroke-linejoin='round' d='M4.867 19.125h.008v.008h-.008v-.008Z' /></svg>" },
+    {"category": "feature", "id": "flrt-helper", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M8.25 9.75h4.875a2.625 2.625 0 0 1 0 5.25H12M8.25 9.75 10.5 7.5M8.25 9.75 10.5 12m9-7.243V21.75l-3.75-1.5-3.75 1.5-3.75-1.5-3.75 1.5V4.757c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0c1.1.128 1.907 1.077 1.907 2.185Z' /></svg>" },
+    {"category": "feature", "id": "hover-profiles", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M15.042 21.672 13.684 16.6m0 0-2.51 2.225.569-9.47 5.227 7.917-3.286-.672Zm-7.518-.267A8.25 8.25 0 1 1 20.25 10.5M8.288 14.212A5.25 5.25 0 1 1 17.25 10.5' /></svg>" },
+    {"category": "feature", "id": "image-upscaling", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z' /></svg>" },
+    {"category": "feature", "id": "inline-wiki", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M4.26 10.147a60.438 60.438 0 0 0-.491 6.347A48.62 48.62 0 0 1 12 20.904a48.62 48.62 0 0 1 8.232-4.41 60.46 60.46 0 0 0-.491-6.347m-15.482 0a50.636 50.636 0 0 0-2.658-.813A59.906 59.906 0 0 1 12 3.493a59.903 59.903 0 0 1 10.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0 1 12 13.489a50.702 50.702 0 0 1 7.74-3.342M6.75 15a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 0v-3.675A55.378 55.378 0 0 1 12 8.443m-7.007 11.55A5.981 5.981 0 0 0 6.75 15.75v-1.5' /></svg>" },
+    {"category": "feature", "id": "inventory-lock-and-hide", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-5 -2 24 24' width='28' fill='currentColor'><path d='M2 12v6h10v-6H2zm10-2a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2V5a5 5 0 1 1 10 0v5zm-2 0V5a3 3 0 1 0-6 0v5h6zm-3 7a2 2 0 1 1 0-4 2 2 0 0 1 0 4z'></path></svg>" },
+    {"category": "feature", "id": "journal-changer", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125' /></svg>" },
+    {"category": "feature", "id": "keyboard-shortcuts", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-2 -5 24 24' width='28' fill='currentColor'><path d='M3 0h14a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H3a3 3 0 0 1-3-3V3a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H3zm0 4h2v2H3V6zm0-3h2v2H3V3zm0 6h2v2H3V9zm3 0h8v2H6V9zm0-3h2v2H6V6zm0-3h2v2H6V3zm3 3h2v2H9V6zm0-3h2v2H9V3zm6 6h2v2h-2V9zm-3-3h2v2h-2V6zm0-3h2v2h-2V3zm3 0h2v5h-2V3z'></path></svg>" },
+    {"category": "feature", "id": "larger-codices", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 24 24' width='28' fill='currentColor'><path d='M12.586 2H11a1 1 0 0 1 0-2h4a1 1 0 0 1 1 1v4a1 1 0 0 1-2 0V3.414L9.414 8 14 12.586V11a1 1 0 0 1 2 0v4a1 1 0 0 1-1 1h-4a1 1 0 0 1 0-2h1.586L8 9.414 3.414 14H5a1 1 0 0 1 0 2H1a1 1 0 0 1-1-1v-4a1 1 0 0 1 2 0v1.586L6.586 8 2 3.414V5a1 1 0 1 1-2 0V1a1 1 0 0 1 1-1h4a1 1 0 1 1 0 2H3.414L8 6.586 12.586 2z'></path></svg>" },
+    {"category": "feature", "id": "larger-skin-images", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z' /></svg>" },
+    {"category": "feature", "id": "lgs-reminder", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -2 24 24' width='28' fill='currentColor'><path d='M2 4.386V8a9.02 9.02 0 0 0 3.08 6.787L8 17.342l2.92-2.555A9.019 9.019 0 0 0 14 8V4.386l-6-2.25-6 2.25zM.649 2.756L8 0l7.351 2.757a1 1 0 0 1 .649.936V8c0 3.177-1.372 6.2-3.763 8.293L8 20l-4.237-3.707A11.019 11.019 0 0 1 0 8V3.693a1 1 0 0 1 .649-.936z'></path></svg>" },
+    {"category": "feature", "id": "location-catch-stats", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z' /></svg>" },
+    {"category": "feature", "id": "location-dashboard", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z' /></svg>" },
+    {"category": "feature", "id": "metric", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418' /></svg>" },
+    {"category": "feature", "id": "only-open-multiple", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z' /></svg>" },
+    {"category": "feature", "id": "open-all-but-one", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M16.5 8.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v8.25A2.25 2.25 0 0 0 6 16.5h2.25m8.25-8.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-7.5A2.25 2.25 0 0 1 8.25 18v-1.5m8.25-8.25h-6a2.25 2.25 0 0 0-2.25 2.25v6' /></svg>" },
+    {"category": "feature", "id": "paste-hunter-id", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336a6.721 6.721 0 0 1-3.17.789 6.721 6.721 0 0 1-3.168-.789 3.376 3.376 0 0 1 6.338 0Z' /></svg>" },
+    {"category": "feature", "id": "prestige-base-stats", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-5 -4 24 24' width='28' fill='currentColor'><path d='M1 0a1 1 0 0 1 1 1v14a1 1 0 0 1-2 0V1a1 1 0 0 1 1-1zm12 4a1 1 0 0 1 1 1v10a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zM7 8a1 1 0 0 1 1 1v6a1 1 0 0 1-2 0V9a1 1 0 0 1 1-1z'></path></svg>" },
+    {"category": "feature", "id": "printing-press-paper-counter", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -2 24 24' width='28' fill='currentColor'><path d='M10.298 2H3a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V4.961L10.298 2zM3 0h8l5 4v13a3 3 0 0 1-3 3H3a3 3 0 0 1-3-3V3a3 3 0 0 1 3-3z'></path></svg>" },
+    {"category": "feature", "id": "profile-scoreboard-search", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' class='feather feather-award'><circle cx='12' cy='8' r='7'/><path d='M8.21 13.89 7 23l5-3 5 3-1.21-9.12'/></svg>" },
+    {"category": "feature", "id": "quick-filters-and-sort", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75' /></svg>" },
+    {"category": "feature", "id": "quick-send-supplies", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5' /></svg>" },
+    {"category": "feature", "id": "show-auras", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-2 -2 24 24' width='28' fill='currentColor'><path d='M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm0 2C4.477 20 0 15.523 0 10S4.477 0 10 0s10 4.477 10 10-4.477 10-10 10z'></path></svg>" },
+    {"category": "feature", "id": "ssdb-teeth-counter", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M21 10.5h.375c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125H21M4.5 10.5h6.75V15H4.5v-4.5ZM3.75 18h15A2.25 2.25 0 0 0 21 15.75v-6a2.25 2.25 0 0 0-2.25-2.25h-15A2.25 2.25 0 0 0 1.5 9.75v6A2.25 2.25 0 0 0 3.75 18Z' /></svg>" },
+    {"category": "feature", "id": "taller-windows", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M3 8.25V18a2.25 2.25 0 0 0 2.25 2.25h13.5A2.25 2.25 0 0 0 21 18V8.25m-18 0V6a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 6v2.25m-18 0h18M5.25 6h.008v.008H5.25V6ZM7.5 6h.008v.008H7.5V6Zm2.25 0h.008v.008H9.75V6Z' /></svg>" },
+    {"category": "feature", "id": "tem-crowns", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z' /></svg>" },
+    {"category": "feature", "id": "ultimate-checkmark-show", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M22 11.08V12a10 10 0 1 1-5.93-9.14'></path><polyline points='22 4 12 14.01 9 11.01'></polyline></svg>" },
+    {"category": "feature", "id": "wisdom-in-stat-bar", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M4.26 10.147a60.438 60.438 0 0 0-.491 6.347A48.62 48.62 0 0 1 12 20.904a48.62 48.62 0 0 1 8.232-4.41 60.46 60.46 0 0 0-.491-6.347m-15.482 0a50.636 50.636 0 0 0-2.658-.813A59.906 59.906 0 0 1 12 3.493a59.903 59.903 0 0 1 10.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0 1 12 13.489a50.702 50.702 0 0 1 7.74-3.342M6.75 15a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 0v-3.675A55.378 55.378 0 0 1 12 8.443m-7.007 11.55A5.981 5.981 0 0 0 6.75 15.75v-1.5' /></svg>" },
+    {"category": "beta", "id": "experiments", "icon": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' d='M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5' /></svg>" }
   ]
 }

--- a/src/modules/better-gifts/settings/index.js
+++ b/src/modules/better-gifts/settings/index.js
@@ -25,6 +25,9 @@ export default async () => {
       value: 'no-skip',
     },
     {
+      seperator: true,
+    },
+    {
       name: 'Skip Mozzarella Cheese only',
       value: 'mozzarella',
     },

--- a/src/modules/better-gifts/styles.css
+++ b/src/modules/better-gifts/styles.css
@@ -455,3 +455,8 @@ a.mousehuntActionButton.giftSelectorView-action-confirm span {
 .giftSelectorView-scroller {
   height: 100%;
 }
+
+.giftSelectorView-inbox-footer-label {
+  margin-top: -30px;
+  text-align: left;
+}

--- a/src/modules/better-gifts/styles.css
+++ b/src/modules/better-gifts/styles.css
@@ -451,3 +451,7 @@ a.mousehuntActionButton.giftSelectorView-action-confirm span {
   margin-right: 150px;
   margin-left: 0;
 }
+
+.giftSelectorView-scroller {
+  height: 100%;
+}

--- a/src/modules/better-inventory/index.js
+++ b/src/modules/better-inventory/index.js
@@ -90,7 +90,7 @@ const addOpenAllToConvertible = () => {
       return;
     }
 
-    input.value = quantity;
+    input.value = Number.parseInt(input.value, 10) > 200 ? 200 : Number.parseInt(input.value, 10);
   });
 };
 

--- a/src/modules/better-journal/index.js
+++ b/src/modules/better-journal/index.js
@@ -1,12 +1,4 @@
-import {
-  addStyles,
-  doEvent,
-  getCurrentPage,
-  getFlag,
-  getSetting,
-  onRequest,
-  setMultipleTimeout
-} from '@utils';
+import { addStyles, getFlag, getSetting } from '@utils';
 
 import journalGoldAndPoints from './journal-gold-and-points';
 import journalHistory from './journal-history';
@@ -21,41 +13,6 @@ import listAndIconsStyles from './list-and-icons.css';
 import styles from './styles.css';
 
 import settings from './settings';
-
-let isProcessing = false;
-const processEntries = async () => {
-  if (! ('camp' === getCurrentPage() || 'hunterprofile' === getCurrentPage())) {
-    return;
-  }
-
-  if (isProcessing) {
-    return;
-  }
-
-  isProcessing = true;
-
-  const entries = document.querySelectorAll('.journal .entry');
-  for (const entry of entries) {
-    doEvent('journal-entry', entry);
-  }
-
-  doEvent('journal-entries', entries);
-
-  isProcessing = false;
-};
-
-const processSingleEntries = async () => {
-  if (isProcessing) {
-    return;
-  }
-
-  isProcessing = true;
-  const entriesEl = document.querySelectorAll('.jsingle .entry');
-  for (const entry of entriesEl) {
-    doEvent('journal-entry', entry);
-  }
-  isProcessing = false;
-};
 
 /**
  * Initialize the module.
@@ -105,15 +62,6 @@ const init = async () => {
   }
 
   journalHistory(getSetting('better-journal.history', getFlag('journal-history', true)));
-
-  processEntries();
-  onRequest('*', (data) => {
-    setMultipleTimeout(processEntries, [100, 500, 1000]);
-
-    if (data.journal_markup && data.journal_markup.length > 0) {
-      processSingleEntries(data.journal_markup);
-    }
-  });
 };
 
 export default {

--- a/src/modules/better-journal/journal-history/index.js
+++ b/src/modules/better-journal/journal-history/index.js
@@ -3,6 +3,7 @@ import {
   dbGet,
   dbGetAll,
   dbSet,
+  doEvent,
   getData,
   makeElement,
   onRequest
@@ -47,7 +48,7 @@ const makeEntriesMarkup = (entries) => {
       }
     }
 
-    if (entry.image) {
+    if (entry.image && ! entry.mouse) {
       html += `<div class="journalimage">${entry.image}</div>`;
     }
 
@@ -74,6 +75,8 @@ const doPageStuff = (page, event = null) => {
   }
 
   journalEntryContainer.append(makeElement('div', 'journal-history-entries', makeEntriesMarkup(journalEntriesForPage)));
+
+  doEvent('journal-history-entry-added', journalEntryContainer);
 };
 
 const getAllEntries = async () => {

--- a/src/modules/better-journal/journal-replacements/index.js
+++ b/src/modules/better-journal/journal-replacements/index.js
@@ -126,6 +126,7 @@ const replacements = [
   ['Lucky me, a prize mouse wandered by and fell for my trap!', '🎉️ A prize mouse fell into my trap!'],
   [/(\d+?,?\d*?) x /gi, ' $1 ', 'shop_purchase'],
   ['In a flash of light my', 'My'],
+  ['Dragon Slayer Cannon</a> found an additional ', 'Dragon Slayer Cannon</a> found another '],
 ];
 
 const replaceInEntry = (entry) => {

--- a/src/modules/better-journal/journal-replacements/index.js
+++ b/src/modules/better-journal/journal-replacements/index.js
@@ -170,7 +170,7 @@ const updateLog = (entry) => {
     return;
   }
 
-  link.classList.add('mh-ui-progress-log-link', 'mousehuntActionButton', 'tiny', 'lightBlue');
+  link.classList.add('mh-ui-progress-log-link', 'mousehuntActionButton', 'small', 'lightBlue');
 
   const span = document.createElement('span');
   span.innerText = 'View Progress Log';

--- a/src/modules/better-journal/journal-styles/index.js
+++ b/src/modules/better-journal/journal-styles/index.js
@@ -1,8 +1,45 @@
-import { addStyles } from '@utils';
+import { addEvent, addStyles } from '@utils';
 
 import * as imported from './styles/**/*.css'; // eslint-disable-line import/no-unresolved
 const styles = imported;
 
+const addBadgeClass = (entry) => {
+  if (! entry) {
+    return;
+  }
+
+  const isBadge = entry.classList.contains('badge');
+  if (! isBadge) {
+    return;
+  }
+
+  const badgeType = entry.querySelector('.journalimage img');
+  if (! badgeType) {
+    return;
+  }
+
+  const badgeTypeClass = badgeType.src
+    .replace('https://www.mousehuntgame.com/images/ui/crowns/crown_', '')
+    .replace('.png', '')
+    .trim();
+
+  entry.classList.add(`better-journal-styles-badge-${badgeTypeClass}`);
+
+  const content = entry.querySelector('.journaltext');
+  if (! content) {
+    return;
+  }
+
+  content.innerHTML = content.innerHTML
+    .replace('I can view my trophy crowns on my', '')
+    .replace('<a href="https://www.mousehuntgame.com/hunterprofile.php?tab=kings_crowns">hunter profile</a>', '')
+    .replace('<br>', '')
+    .replace('.', '')
+    .trim();
+};
+
 export default async () => {
   addStyles(styles, 'better-journal-styles');
+
+  addEvent('journal-entry', addBadgeClass, { id: 'better-journal-styles-badge' });
 };

--- a/src/modules/better-journal/journal-styles/styles/custom-entries/badge.css
+++ b/src/modules/better-journal/journal-styles/styles/custom-entries/badge.css
@@ -1,0 +1,63 @@
+.journal .content .entry.badge {
+  z-index: 1;
+  margin-bottom: -1px;
+  background: linear-gradient(135deg, #eee 0%, #c6d8ee 50%);
+  border: 1px solid #5b5b5b;
+  transition: transform 0.3s ease-in-out;
+}
+
+.journal .content .entry.badge:hover {
+  transform: scale(1.1);
+}
+
+.journal .content .entry.badge:hover,
+.journal .content .entry.badge {
+  animation: mh-improved-glow 1s 2;
+}
+
+.journal .content .entry.badge .journalimage {
+  width: 80px;
+  height: 80px;
+  margin: 0;
+}
+
+.journal .content .entry.badge .journalimage img {
+  width: 65px;
+  transition: 0.3s ease-in-out;
+}
+
+.journal .content .entry.badge:hover .journalimage img {
+  transform: rotate(-10deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .journal .content .entry.badge,
+  .journal .content .entry.badge:hover {
+    transform: none;
+    animation: none;
+  }
+
+  .journal .content .entry.badge .journalimage img {
+    transform: none;
+  }
+}
+
+.entry.short.badge.better-journal-styles-badge-bronze {
+  background: linear-gradient(135deg, #eee, #f6b584 80%);
+}
+
+.entry.short.badge.better-journal-styles-badge-silver {
+  background: linear-gradient(135deg, #eee, #c6d8ee 50%);
+}
+
+.entry.short.badge.better-journal-styles-badge-gold {
+  background: linear-gradient(135deg, #eee, #fff24e 80%);
+}
+
+.entry.short.badge.better-journal-styles-badge-platinum {
+  background: linear-gradient(135deg, #eee, #c3b8ff 80%);
+}
+
+.entry.short.badge.better-journal-styles-badge-diamond {
+  background: linear-gradient(135deg, #eee, #8bdae9 80%);
+}

--- a/src/modules/better-journal/journal-styles/styles/custom-entries/catch/badge.css
+++ b/src/modules/better-journal/journal-styles/styles/custom-entries/catch/badge.css
@@ -1,9 +1,0 @@
-.entry.short.badge {
-  animation: townOfGnawniaHighlightAction 1s 2;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .entry.short.badge {
-    animation: none;
-  }
-}

--- a/src/modules/better-journal/journal-styles/styles/custom-entries/location/floating-islands.css
+++ b/src/modules/better-journal/journal-styles/styles/custom-entries/location/floating-islands.css
@@ -1,0 +1,4 @@
+.journal .entry.floatingIslands.dirigibleTravel {
+  max-height: 103px;
+  overflow-y: auto;
+}

--- a/src/modules/better-journal/journal-styles/styles/fullstop.css
+++ b/src/modules/better-journal/journal-styles/styles/fullstop.css
@@ -15,6 +15,7 @@
 
 .journal .content .entry .journaltext > br + br:last-of-type,
 .journal .content .entry.floatingIslands.fullyExplored .journaltext br,
+.journal .content .entry.floatingIslands.defeatedEnemy .journaltext br,
 .journal .content .entry.harbour br {
   display: block;
 }
@@ -39,7 +40,6 @@
 .journal .entry.relicHunter_complete .journaltext b:last-of-type::after,
 .entry.halloween_boiling_cauldron.brew_finished a:last-of-type::after,
 .entry.halloween_boiling_cauldron.brew_removed a:last-of-type::after,
-.entry.badge .journaltext a::after,
 .entry.folkloreForest-farmToTable .journaltext a:last-of-type::after,
 .entry.folkloreForest-forewordFarm.folkloreForest-plantStarted .journaltext a::after,
 .entry.festiveSpiritLootBoost .journaltext a::after,

--- a/src/modules/better-journal/journal-styles/styles/progress-log.css
+++ b/src/modules/better-journal/journal-styles/styles/progress-log.css
@@ -5,14 +5,18 @@
 
 .journal .entry.log_summary .journaltext b {
   display: block;
+  width: 30%;
   padding-top: 0.5em;
+  padding-bottom: 5px;
+  margin: 0 auto;
   font-weight: 900;
+  border-bottom: 1px solid #c6c6c6;
 }
 
 /* Progress log */
 .mh-ui-progress-log-link {
   display: block;
-  width: 100px;
+  width: 50%;
   margin: 1em auto;
 }
 
@@ -162,6 +166,7 @@
 }
 
 .reportTitle {
+  margin-bottom: 5px;
   font-size: 1.5em;
 }
 

--- a/src/modules/better-maps/index.js
+++ b/src/modules/better-maps/index.js
@@ -118,7 +118,7 @@ const initMapper = (map) => {
     });
   });
 
-  if (getSetting('better-maps.show-sorted-tab', false)) {
+  if (getSetting('better-maps.default-to-sorted', false)) {
     doEvent('map_sorted_tab_click', map);
   } else {
     // Fire the goals click because we default to that tab.
@@ -224,8 +224,13 @@ const updateRelicHunterHint = async () => {
   return true;
 };
 
+let _showInventory;
 const relicHunterUpdate = () => {
-  const _showInventory = hg.controllers.TreasureMapController.showInventory;
+  if (_showInventory) {
+    return;
+  }
+
+  _showInventory = hg.controllers.TreasureMapController.showInventory;
   hg.controllers.TreasureMapController.showInventory = () => {
     _showInventory();
 

--- a/src/modules/better-maps/index.js
+++ b/src/modules/better-maps/index.js
@@ -5,6 +5,8 @@ import {
   getMapData,
   getSetting,
   makeElement,
+  onDialogShow,
+  onEvent,
   onRequest,
   sessionSet,
   setGlobal,
@@ -20,10 +22,24 @@ import { hideGoalsTab, showGoalsTab } from './modules/tab-goals';
 import { showHuntersTab } from './modules/tab-hunters';
 
 import community from './modules/community';
+import shops from './modules/shops';
 import sidebar from './modules/sidebar';
 
 import * as imported from './styles/*.css'; // eslint-disable-line import/no-unresolved
 const styles = imported;
+
+const updateMapClasses = () => {
+  const map = document.querySelector('.treasureMapRootView');
+  if (user?.quests?.QuestRelicHunter?.maps?.length >= 2) {
+    map.classList.add('mh-ui-multiple-maps');
+  } else {
+    map.classList.remove('mh-ui-multiple-maps');
+  }
+};
+
+const updateBlockContent = (block) => {
+  console.log('updateBlockContent', block);
+};
 
 const addBlockClasses = () => {
   const rightBlocks = document.querySelectorAll('.treasureMapView-rightBlock > div');
@@ -45,6 +61,8 @@ const addBlockClasses = () => {
     } else {
       block.classList.add(`mh-ui-${prevBlockType}-block`);
     }
+
+    updateBlockContent(block);
   });
 };
 
@@ -267,6 +285,7 @@ const init = async () => {
   intercept();
 
   relicHunterUpdate();
+  shops();
 
   if (getSetting('better-maps.community')) {
     community();
@@ -279,6 +298,31 @@ const init = async () => {
   if (! getSetting('no-sidebar') && getSetting('better-maps.show-sidebar-goals', true)) {
     sidebar();
   }
+
+  onDialogShow('map', () => {
+    const tabs = document.querySelectorAll('.treasureMapRootView-header-navigation-item');
+    tabs.forEach((tab) => {
+      const classes = [...tab.classList];
+
+      if (classes.includes('active')) {
+        doEvent('map_navigation_tab_click', classes.find((c) => c !== 'treasureMapRootView-header-navigation-item').trim());
+      }
+
+      tab.addEventListener('click', () => {
+        doEvent('map_navigation_tab_click', classes.find((c) => c !== 'treasureMapRootView-header-navigation-item' && c !== 'active').trim());
+      });
+    });
+  });
+
+  onEvent('map_navigation_tab_click', () => {
+    addBlockClasses();
+    updateMapClasses();
+  });
+
+  onRequest('users/treasuremap.php', () => {
+    addBlockClasses();
+    updateMapClasses();
+  });
 };
 
 export default {

--- a/src/modules/better-maps/index.js
+++ b/src/modules/better-maps/index.js
@@ -37,10 +37,6 @@ const updateMapClasses = () => {
   }
 };
 
-const updateBlockContent = (block) => {
-  console.log('updateBlockContent', block);
-};
-
 const addBlockClasses = () => {
   const rightBlocks = document.querySelectorAll('.treasureMapView-rightBlock > div');
   const leftBlocks = document.querySelectorAll('.treasureMapView-leftBlock > div');
@@ -61,8 +57,6 @@ const addBlockClasses = () => {
     } else {
       block.classList.add(`mh-ui-${prevBlockType}-block`);
     }
-
-    updateBlockContent(block);
   });
 };
 

--- a/src/modules/better-maps/modules/shops.js
+++ b/src/modules/better-maps/modules/shops.js
@@ -1,7 +1,6 @@
 import { onRequest } from '@utils';
 
 const updateShopsMarkup = async () => {
-  console.log('updateShopsMarkup');
   const shops = document.querySelectorAll('.treasureMapShopsView-shopItems .treasureMapPopup-shop');
   if (! shops.length) {
     return;

--- a/src/modules/better-maps/modules/shops.js
+++ b/src/modules/better-maps/modules/shops.js
@@ -1,0 +1,55 @@
+import { onRequest } from '@utils';
+
+const updateShopsMarkup = async () => {
+  console.log('updateShopsMarkup');
+  const shops = document.querySelectorAll('.treasureMapShopsView-shopItems .treasureMapPopup-shop');
+  if (! shops.length) {
+    return;
+  }
+
+  shops.forEach((shop) => {
+    const environment = shop.querySelector('.treasureMapPopup-shop-environment');
+    if (! environment) {
+      return;
+    }
+
+    const heading = environment.querySelector('.treasureMapView-block-content-heading');
+    if (! heading) {
+      return;
+    }
+
+    const container = environment.querySelector('.treasureMapPopup-shop-environmentItems');
+    if (! container) {
+      return;
+    }
+
+    if (! environment.classList.contains('active')) {
+      container.classList.add('hidden');
+    }
+
+    heading.addEventListener('click', () => {
+      container.classList.toggle('hidden');
+    });
+  });
+};
+
+const updateFromClick = async () => {
+  const _showShops = hg.controllers.TreasureMapController.showShops;
+  hg.controllers.TreasureMapController.showShops = (data) => {
+    _showShops(data);
+    updateShopsMarkup();
+  };
+};
+
+const updateFromRequest = (response, data) => {
+  if (data?.action !== 'get_shops') {
+    return;
+  }
+
+  updateShopsMarkup();
+};
+
+export default async () => {
+  updateFromClick();
+  onRequest('users/treasuremap.php', updateFromRequest);
+};

--- a/src/modules/better-maps/modules/tab-goals.js
+++ b/src/modules/better-maps/modules/tab-goals.js
@@ -4,6 +4,7 @@ import {
   doRequest,
   makeElement,
   makeLink,
+  onEvent,
   sessionGet,
   sessionSet,
   showErrorMessage
@@ -495,7 +496,7 @@ const addSidebarToggle = async () => {
   leftBlock.append(toggle);
 };
 
-const makeStickyDraggable = () => {
+const makeStickyDraggable = (isClone = false) => {
   const sticky = document.querySelector('.treasureMapView-highlight');
   if (! sticky) {
     return;
@@ -534,9 +535,50 @@ const makeStickyDraggable = () => {
   const closeDragElement = () => {
     document.onmouseup = null;
     document.onmousemove = null;
+
+    if (! isClone) {
+      const existing = document.querySelector('.better-maps-sticky-clone');
+      if (existing) {
+        existing.remove();
+      }
+
+      clone = sticky.cloneNode(true);
+      clone.classList.add('hidden', 'better-maps-sticky-clone');
+
+      // calculate the position of the clone because the sticky is positioned absolute and the clone is positioned fixed.
+      const rect = sticky.getBoundingClientRect();
+      clone.style.top = `${rect.top}px`;
+      clone.style.left = `${rect.left}px`;
+      clone.style.width = `${rect.width}px`;
+
+      const cloneClose = clone.querySelector('.treasureMapView-highlight-close');
+      if (cloneClose) {
+        cloneClose.addEventListener('click', () => {
+          clone.classList.add('hidden');
+        });
+      }
+
+      document.body.append(clone);
+    }
   };
 
   sticky.onmousedown = dragMouseDown;
+};
+
+let clone;
+const onMapOpen = () => {
+  if (clone) {
+    clone.classList.add('hidden');
+  }
+};
+
+const onMapClose = () => {
+  if (clone) {
+    clone.classList.remove('hidden');
+
+    // Allow the user to drag the sticky around again.
+    makeStickyDraggable(true);
+  }
 };
 
 const showGoalsTab = async (mapData) => {
@@ -548,6 +590,9 @@ const showGoalsTab = async (mapData) => {
   addQuickInvite(mapData);
   addSidebarToggle();
   makeStickyDraggable();
+
+  onEvent('dialog-show-map', onMapOpen);
+  onEvent('dialog-hide-map', onMapClose);
 };
 
 const hideGoalsTab = () => {

--- a/src/modules/better-maps/settings/index.js
+++ b/src/modules/better-maps/settings/index.js
@@ -12,7 +12,6 @@ export default async () => {
     {
       id: 'better-maps.show-sidebar-goals',
       title: 'Show map goals in sidebar',
-      default: true,
     },
   ];
 };

--- a/src/modules/better-maps/styles/general.css
+++ b/src/modules/better-maps/styles/general.css
@@ -7,6 +7,10 @@
   border-radius: 2px;
 }
 
+.treasureMapView-block-content {
+  height: unset;
+}
+
 .treasureMapView-block-content.halfHeight {
   padding: 0;
   border-radius: 0;
@@ -154,24 +158,6 @@ img.treasureMapView-reward-chestIcon {
   font-size: 10px;
 }
 
-.treasureMapShopsView .treasureMapView-leftBlock {
-  width: 99%;
-}
-
-.treasureMapShopsView .treasureMapView-rightBlock {
-  display: none;
-}
-
-.treasureMapPopup-shop {
-  margin-bottom: 10px;
-  background-color: #fbfbfb;
-  border-radius: 5px;
-}
-
-.treasureMapPopup-shop-environment.active::before {
-  box-shadow: none;
-}
-
 .treasureMapView-block-content-heading {
   margin: 10px 0 5px;
 }
@@ -189,10 +175,6 @@ img.treasureMapView-reward-chestIcon {
   color: #000;
   background-color: rgb(50 50 50 / 25%);
   border-color: #424242;
-}
-
-.mh-dark-mode .treasureMapPopup-shop-item-description-costContainer {
-  border-top-color: #424242;
 }
 
 .treasureMapView-block-content-heading-image {
@@ -352,7 +334,6 @@ img.treasureMapView-reward-chestIcon {
   justify-content: flex-start;
   padding-top: 5px;
   margin-top: 10px;
-  border-top: 1px solid #ccc;
 }
 
 .treasureMapInventoryView-scrollCase-name {
@@ -611,6 +592,7 @@ input.treasureMapView-block-search-text {
 
 .treasureMapView-block-content.treasureMapInvitesView-scoreboards {
   padding: 2px;
+  margin-top: -20px;
   overflow-x: hidden;
 }
 
@@ -675,6 +657,7 @@ input.treasureMapView-block-search-text {
 /* Make the relic hunter image bigger */
 .treasureMapInventoryView-relicHunter {
   padding-top: 120px;
+  border-radius: 3px;
 }
 
 .treasureMapInventoryView-relicHunter::before {
@@ -689,6 +672,9 @@ input.treasureMapView-block-search-text {
 
 .treasureMapPopup-seasonContainer.mousehuntTooltipParent {
   font-size: 11px;
+  background: transparent;
+  border: 1px solid #ccc;
+  border-radius: 3px;
 }
 
 .treasureMapInventoryView .treasureMapView-block-search {
@@ -788,9 +774,14 @@ input.treasureMapView-block-search-text {
   top: -9px;
 }
 
+.treasureMapPopup-mapInvite .treasureMapTooltipView.active {
+  min-height: 35px;
+  transform: translateY(-40px);
+}
+
 .treasureMapTooltipView.active {
   min-height: 35px;
-  transform: translateY(10px);
+  transform: translateY(15px);
 }
 
 .treasureMapView-mapWarning.treasureMapRootView-padding {
@@ -832,17 +823,6 @@ input.treasureMapView-block-search-text {
 
 .treasureMapView-goals-group-goal.complete.landscape .treasureMapView-goals-group-goal-image {
   height: 33px;
-}
-
-.treasureMapPopup-shop .treasureMapView-block-content-heading {
-  padding: 10px 0 0 10px;
-  margin: 0;
-  border-color: transparent;
-}
-
-.treasureMapPopup-shop-environment {
-  padding-bottom: 5px;
-  margin-bottom: 5px;
 }
 
 .treasureMapView-goals-group-goal:hover::before,
@@ -917,4 +897,30 @@ input.treasureMapView-block-search-text {
 
 .mh-improved-map-listing-full {
   opacity: 0.5;
+}
+
+.treasureMapPopup-mapInvite .treasureMapInventoryView-scrollCase {
+  padding: 0;
+  margin: 5px 0;
+  border: none;
+}
+
+.treasureMapView-block-content.tall.treasureMapInvitesView-inviteList {
+  padding: 5px;
+}
+
+.treasureMapPopup-mapInvite .treasureMapView-block-content-heading {
+  margin: 0;
+}
+
+.treasureMapPopup-mapInvite {
+  padding: 5px;
+}
+
+.treasureMapView-scoreboard {
+  border-radius: 3px;
+}
+
+.treasureMapView-scoreboard .treasureMapView-block-cell.rank {
+  padding-left: 2px;
 }

--- a/src/modules/better-maps/styles/general.css
+++ b/src/modules/better-maps/styles/general.css
@@ -791,7 +791,6 @@ input.treasureMapView-block-search-text {
   box-shadow: 0 0 1px 1px #ffa5a5;
 }
 
-.treasureMapView-consolationPrize-message,
 .treasureMapView-consolationPrizeMessage {
   margin: 15px 0;
   box-shadow: 0 0 1px 1px #ffa5a5;

--- a/src/modules/better-maps/styles/general.css
+++ b/src/modules/better-maps/styles/general.css
@@ -489,11 +489,6 @@ img.mh-mapper-consolation-prize {
   display: none;
 }
 
-.treasureMapView-block-search {
-  right: 7px;
-  bottom: 15px;
-}
-
 input.treasureMapView-block-search-text {
   height: 18px;
   font-size: 12px;
@@ -677,8 +672,9 @@ input.treasureMapView-block-search-text {
   border-radius: 3px;
 }
 
-.treasureMapInventoryView .treasureMapView-block-search {
+.treasureMapView-block-search {
   right: 0;
+  bottom: 25px;
 }
 
 .treasureMapInventoryView .treasureMapView-block-title,
@@ -773,15 +769,22 @@ input.treasureMapView-block-search-text {
 .treasureMapView-hunter-icon {
   top: -9px;
 }
-
-.treasureMapPopup-mapInvite .treasureMapTooltipView.active {
-  min-height: 35px;
-  transform: translateY(-40px);
+/*
+.treasureMapDialogView.wide.limitHeight.confirm {
+  transform: translate(-50%, -130px);
 }
 
 .treasureMapTooltipView.active {
   min-height: 35px;
-  transform: translateY(15px);
+  transform: translateY(20px);
+} */
+
+.treasureMapTooltipView.active {
+  top: 0 !important;
+}
+
+.mh-ui-multiple-maps .treasureMapTooltipView.active {
+  top: 30px !important;
 }
 
 .treasureMapView-mapWarning.treasureMapRootView-padding {
@@ -923,4 +926,104 @@ input.treasureMapView-block-search-text {
 
 .treasureMapView-scoreboard .treasureMapView-block-cell.rank {
   padding-left: 2px;
+}
+
+.treasureMapRootView-footer {
+  margin-top: 0;
+}
+
+.treasureMapInventoryView .treasureMapView-blockWrapper .treasureMapView-leftBlock .treasureMapView-block {
+  padding: 0;
+  margin-top: -25px;
+  border: none;
+}
+
+.treasureMapInventoryView .treasureMapView-blockWrapper .treasureMapView-block-content-heading {
+  margin: 10px 10px 5px;
+  border: none;
+}
+
+.treasureMapInventoryView .treasureMapView-rightBlock {
+  margin-top: -46px;
+}
+
+.treasureMapInventoryView .treasureMapView-blockWrapper .treasureMapView-leftBlock .treasureMapView-block-content {
+  margin-left: -10px;
+}
+
+.treasureMapInventoryView-scrollCase-content br + br {
+  display: none;
+}
+
+.treasureMapInventoryView-scrollCase-content {
+  line-height: 16px;
+}
+
+.treasureMapInventoryView-scrollCase-content br + br + b {
+  display: inline-block;
+}
+
+.treasureMapView-block-title.mh-ui-maps-title,
+.treasureMapView-block-title.mh-ui-map-scrolls-title,
+.treasureMapView-block-title.mh-ui-scroll-shop-title {
+  display: none;
+}
+
+.treasureMapShopsView .treasureMapView-block-search {
+  bottom: 20px;
+}
+
+.treasureMapTooltipView-hunterText-state.captain {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  visibility: hidden;
+}
+
+.treasureMapTooltipView-hunterText-state.captain:after {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 18px;
+  height: 16px;
+  background: url(https://www.mousehuntgame.com/images/ui/tournaments/captain_icon.png?asset_cache_version=3) no-repeat 50% 50% / contain;
+  content: "";
+  visibility: visible;
+}
+
+.treasureMapTooltipView-hunterText-state.upgrader {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  visibility: hidden;
+}
+
+.treasureMapTooltipView-hunterText-state.upgrader:after {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 16px;
+  height: 16px;
+  background: #ffb615;
+border-radius: 50%;
+  content: "";
+  visibility: visible;
+}
+
+.treasureMapView-hunter-wrapper .quickSendWrapper {
+  top: 60px !important;
+left: 30px;
+}
+
+.treasureMapTooltipView {
+  height: 45px;
+}
+
+.treasureMapTooltipView.active {
+
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    flex-direction: column;
+    align-content: space-around;
 }

--- a/src/modules/better-maps/styles/general.css
+++ b/src/modules/better-maps/styles/general.css
@@ -769,18 +769,13 @@ input.treasureMapView-block-search-text {
 .treasureMapView-hunter-icon {
   top: -9px;
 }
-/*
-.treasureMapDialogView.wide.limitHeight.confirm {
-  transform: translate(-50%, -130px);
-}
-
-.treasureMapTooltipView.active {
-  min-height: 35px;
-  transform: translateY(20px);
-} */
 
 .treasureMapTooltipView.active {
   top: 0 !important;
+  display: flex;
+  flex-direction: column;
+  place-content: flex-start space-around;
+  align-items: center;
 }
 
 .mh-ui-multiple-maps .treasureMapTooltipView.active {
@@ -796,6 +791,7 @@ input.treasureMapView-block-search-text {
   box-shadow: 0 0 1px 1px #ffa5a5;
 }
 
+.treasureMapView-consolationPrize-message,
 .treasureMapView-consolationPrizeMessage {
   margin: 15px 0;
   box-shadow: 0 0 1px 1px #ffa5a5;
@@ -980,15 +976,15 @@ input.treasureMapView-block-search-text {
   visibility: hidden;
 }
 
-.treasureMapTooltipView-hunterText-state.captain:after {
+.treasureMapTooltipView-hunterText-state.captain::after {
   position: absolute;
-  left: 0;
   top: 0;
+  left: 0;
   width: 18px;
   height: 16px;
-  background: url(https://www.mousehuntgame.com/images/ui/tournaments/captain_icon.png?asset_cache_version=3) no-repeat 50% 50% / contain;
-  content: "";
   visibility: visible;
+  content: "";
+  background: url(https://www.mousehuntgame.com/images/ui/tournaments/captain_icon.png?asset_cache_version=3) no-repeat 50% 50% / contain;
 }
 
 .treasureMapTooltipView-hunterText-state.upgrader {
@@ -998,32 +994,30 @@ input.treasureMapView-block-search-text {
   visibility: hidden;
 }
 
-.treasureMapTooltipView-hunterText-state.upgrader:after {
+.treasureMapTooltipView-hunterText-state.upgrader::after {
   position: absolute;
-  right: 0;
   top: 0;
+  right: 0;
   width: 16px;
   height: 16px;
-  background: #ffb615;
-border-radius: 50%;
-  content: "";
   visibility: visible;
+  content: "";
+  background: #ffb615;
+  border-radius: 50%;
 }
 
 .treasureMapView-hunter-wrapper .quickSendWrapper {
   top: 60px !important;
-left: 30px;
+  left: 30px;
 }
 
 .treasureMapTooltipView {
   height: 45px;
 }
 
-.treasureMapTooltipView.active {
-
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    flex-direction: column;
-    align-content: space-around;
+.treasureMapTooltipView-hunterText {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
 }

--- a/src/modules/better-maps/styles/scroll-shop.css
+++ b/src/modules/better-maps/styles/scroll-shop.css
@@ -1,0 +1,83 @@
+.treasureMapPopup-shop .treasureMapView-block-content-heading {
+  padding: 10px;
+  margin: 0;
+  border-color: transparent;
+}
+
+.treasureMapInventoryView-scrollCase:first-of-type {
+  margin-top: 0;
+}
+
+.treasureMapPopup-shop-environment {
+  padding-bottom: 0;
+  margin-bottom: 5px;
+  border: 1px solid rgb(0 0 0 / 12%);
+  border-radius: 3px;
+}
+
+.treasureMapShopsView .treasureMapView-leftBlock {
+  width: 99%;
+  height: 600px;
+}
+
+.treasureMapShopsView .treasureMapView-rightBlock {
+  display: none;
+}
+
+.treasureMapPopup-shop {
+  margin-bottom: 10px;
+  background-color: #fbfbfb;
+  border-radius: 3px;
+}
+
+.treasureMapPopup-shop-environment.active::before {
+  box-shadow: none;
+}
+
+.treasureMapView-block-content.treasureMapShopsView-shopItems {
+  padding: 0;
+}
+
+.treasureMapShopsView .treasureMapView-blockWrapper .treasureMapView-leftBlock > .treasureMapView-block {
+  height: calc(100% - 18px);
+  overflow-y: auto;
+  border: none;
+}
+
+.treasureMapInventoryView-scrollCase-content div[style="border: 1px red dotted; padding: 5px; font-size: 10px;"] {
+  display: none;
+}
+
+b[style="color:red; font-size: 14px;"],
+b[style="color:red; font-size: 14px;"] + br {
+  display: none;
+}
+
+/*
+.map-shop-environment-title {
+  list-style: none;
+  display: flex;
+  align-items: center;
+}
+
+.map-shop-environment-title::marker {
+    display: none
+}
+
+.map-shop-environment-title::after {
+  content: '';
+  position: absolute;
+    top: 15px;
+    right: 20px;
+    width: 0;
+    height: 0;
+    border-right: 6px solid transparent;
+    border-bottom: 9px solid #555;
+    border-left: 6px solid transparent;
+    transition: transform .15s;
+}
+
+details[open] summary.map-shop-environment-title:after {
+  content: "";
+  transform: rotate(-180deg);
+} */

--- a/src/modules/better-maps/styles/sorted.css
+++ b/src/modules/better-maps/styles/sorted.css
@@ -86,15 +86,17 @@
 }
 
 #sorted-mice-container .mouse-container-selected .mouse-mhct-extra-info-wrapper {
-  position: absolute;
+  position: fixed;
   z-index: 10;
   display: block;
+  width: 350px;
   padding: 10px 5px;
   margin: -5px -10px;
   background-color: #eaeaea;
-  border: 1px solid #000;
+  border: 1px solid #a8a8a8;
   border-radius: 3px;
-  box-shadow: 0 10px 15px 0 rgb(0 0 0 / 53%);
+  box-shadow: 0 10px 15px 0 rgb(0 0 0 / 50%);
+  transform: translate(calc((200px - 350px) / 2), -5px);
 }
 
 #sorted-mice-container .mouse-subcategory-mice .mouse-container-selected .mouse-mhct-extra-info-wrapper {
@@ -166,6 +168,7 @@
 #sorted-mice-container .mouse-weakness {
   display: flex;
   align-items: center;
+  justify-content: center;
   margin-top: 10px;
 }
 

--- a/src/modules/better-maps/styles/sticky.css
+++ b/src/modules/better-maps/styles/sticky.css
@@ -1,0 +1,3 @@
+.treasureMapView-highlight.hidden.better-maps-sticky-clone {
+  display: none;
+}

--- a/src/modules/better-send-supplies/index.js
+++ b/src/modules/better-send-supplies/index.js
@@ -201,7 +201,7 @@ const addQuickQuantityButtons = () => {
     classNames: ['mhui-supply-quick-quantity', 'gray', 'small'],
   });
 
-  const max = makeElement('button', ['mousehuntActionButton', 'lightBlue', 'small', 'mhui-supply-quick-quantity', 'mhui-supply-quick-quantit-max']);
+  const max = makeElement('button', ['mousehuntActionButton', 'lightBlue', 'small', 'mhui-supply-quick-quantity', 'mhui-supply-quick-quantity-max']);
   const maxText = makeElement('span', '', 'Max');
 
   max.addEventListener('click', () => {

--- a/src/modules/better-send-supplies/index.js
+++ b/src/modules/better-send-supplies/index.js
@@ -41,21 +41,19 @@ const addSearch = () => {
   }
 
   const form = makeElement('form', 'mhui-supply-search-form');
-  const label = makeElement('label', ['mhui-supply-search-label', 'screen-reader-only']);
+  const label = makeElement('label', ['mhui-supply-search-label']);
   label.setAttribute('for', 'mhui-supply-search-input');
-  makeElement('span', '', 'Search for an item', label);
-
-  form.append(label);
+  makeElement('span', '', 'Search: ', label);
 
   const input = makeElement('input', 'mhui-supply-search-input');
   input.setAttribute('type', 'text');
   input.setAttribute('id', 'mhui-supply-search-input');
-  input.setAttribute('placeholder', 'Search for an item');
   input.setAttribute('autocomplete', 'off');
 
   input.addEventListener('keyup', processSearch);
 
-  form.append(input);
+  label.append(input);
+  form.append(label);
 
   // Convert the title into a wrapper that has the title and our form
   const titleWrapper = makeElement('div', 'mhui-supply-search');
@@ -268,6 +266,14 @@ const upgradeSendSupplies = (initial = false) => {
     if (inputVal) {
       inputVal.focus();
     }
+  }
+
+  const categories = document.querySelectorAll('#supplytransfer .categoryMenu a');
+  for (const category of categories) {
+    category.addEventListener('click', () => {
+      // re-sort the pinned items
+      highlightFavoritedItems();
+    }, { once: true });
   }
 
   sendTo.addEventListener('click', () => {

--- a/src/modules/better-send-supplies/settings/index.js
+++ b/src/modules/better-send-supplies/settings/index.js
@@ -8,10 +8,7 @@ import { getTradableItems } from '@utils';
 export default async () => {
   const tradableItems = await getTradableItems('truncated_name');
 
-  tradableItems.unshift({
-    name: 'None',
-    value: '',
-  });
+  tradableItems.unshift({ name: 'None', value: 'none' }, { seperator: true });
 
   return [{
     id: 'better-send-supplies.pinned-items',

--- a/src/modules/better-send-supplies/styles.css
+++ b/src/modules/better-send-supplies/styles.css
@@ -3,27 +3,25 @@
 }
 
 #supplytransfer .listContainer a.element.recipient {
-  width: 81px;
-  height: 71px;
+  width: auto;
+  height: auto;
   white-space: nowrap;
+  background-color: #fff;
 }
 
 #supplytransfer .tabContent.recipient .listContainer span.content {
   font-size: 12px;
 }
 
-#supplytransfer .listContainer a.element.item.pinned:hover,
-#supplytransfer .listContainer a.element:hover {
-  background-color: #d8f0ff;
-}
-
 #supplytransfer .listContainer a.element.item {
   display: grid;
-  grid-template-rows: 60px 20px;
-  align-content: space-around;
-  justify-items: center;
-  width: 85px;
-  height: 90px;
+  grid-template-rows: 1fr 1fr;
+  align-items: center;
+  width: auto;
+  height: 100px;
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
 }
 
 #supplytransfer .listContainer a.element.item,
@@ -33,28 +31,28 @@
 }
 
 #supplytransfer .listContainer a.element:hover,
-#supplytransfer .listContainer a.element:focus,
 #supplytransfer .listContainer a.element.recipient:hover,
-#supplytransfer .listContainer a.element.recipient:focus {
-  border-color: #b3b3b3;
-}
-
-#supplytransfer .itemList a.element .quantity {
-  bottom: 20px;
+#supplytransfer .listContainer a.element.item.pinned:hover,
+#supplytransfer .tabs .tab .image:hover,
+#supplytransfer .tabs .tab .image.empty:hover {
+  color: #3b5998;
+  background-color: #d8f0ff;
+  border-color: #ccc;
 }
 
 #supplytransfer .tabContent.item .listContainer {
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-evenly;
-  width: auto;
-  margin-left: 75px;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 5px;
+  width: 550px;
+  max-height: unset;
+  margin-bottom: 0;
+  margin-left: 90px;
 }
 
 #supplytransfer .categoryMenu {
-  width: 70px;
-  padding-left: 5px;
-  background-color: #fff;
+  position: fixed;
+  width: 90px;
+  background: none;
 }
 
 #supplytransfer .categoryMenu a {
@@ -63,13 +61,16 @@
   text-align: left;
 }
 
-#supplytransfer .itemList a.element .itemImage img {
+#supplytransfer .itemList .element .itemImage img {
   width: 60px;
   height: 60px;
 }
 
 #supplytransfer .listContainer a.element .details {
+  width: 90px;
+  margin: 0 auto;
   font-size: 11px;
+  text-align: center;
 }
 
 #supplytransfer .categoryMenu a:hover,
@@ -81,46 +82,25 @@
   background-color: #d8f0ff;
 }
 
-#supplytransfer .drawer {
-  padding-bottom: 40px;
-  margin-bottom: 10px;
-}
-
 .mhui-supply-search {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 5px;
-  margin: 5px;
-  margin-left: 0;
-  line-height: 20px;
-}
-
-input.mhui-supply-search-input {
-  padding: 9px;
-  margin-right: -2px;
-}
-
-form.mhui-supply-search-form {
-  display: flex;
-  align-items: center;
+  padding-bottom: 5px;
+  margin: 5px 5px 15px;
+  border-bottom: 1px solid #ccc;
 }
 
 #supplytransfer .drawer .tabContent .searchContainer {
   position: absolute;
   top: -5px;
-  right: 26px;
+  right: 0;
 }
 
 #supplytransfer .drawer .tabContent h2 {
-  display: inline-block;
-  min-width: 230px;
-  padding-bottom: 0;
-  margin-bottom: 0;
-  margin-left: 8px;
-  font-size: 15px;
-  font-weight: 400;
-  line-height: unset;
+  padding: 0;
+  margin: 0;
+  margin-right: auto;
+  font-size: 14px;
   border: none;
 }
 
@@ -139,9 +119,7 @@ form.mhui-supply-search-form {
   flex-direction: row;
   gap: 5px;
   align-items: center;
-  justify-content: flex-end;
-  width: 30%;
-  margin-right: 5px;
+  margin-right: 10px;
 }
 
 .mhui-supply-sort-wrapper a {
@@ -179,4 +157,137 @@ form.mhui-supply-search-form {
   padding-top: 10px;
   margin-top: 10px;
   border-top: 1px solid #ccc;
+}
+
+#supplytransfer .tabs .tab.recipient .image.empty::after,
+#supplytransfer .tabs .tab.item .image.empty::after {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #3b5998;
+  cursor: pointer;
+  content: "";
+}
+
+#supplytransfer .tabs .tab.recipient .image.empty::after {
+  content: "Select Friend";
+}
+
+#supplytransfer .tabs .tab.item .image.empty::after {
+  content: "Select Item";
+}
+
+#supplytransfer .drawer .tabContent.confirm #supplytransfer-confirm-text {
+  padding: 0;
+}
+
+#supplytransfer .tabs .tab.confirm {
+  display: none;
+}
+
+#supplytransfer .tabs .tab.recipient .image.empty,
+#supplytransfer .tabs .tab.item .image.empty {
+  position: relative;
+  margin-bottom: -20px;
+  background-image: none;
+}
+
+#supplytransfer .tabs .tab .image {
+  background: #ccc;
+  border: 1px solid #eee;
+}
+
+.PageSupplyTransfer .flexibleDialogWarmBrown {
+  padding: 0;
+  background: none;
+  box-shadow: none;
+}
+
+#supplytransfer .drawer {
+  width: unset;
+  height: 100%;
+  max-height: unset;
+  padding: 5px;
+  border: none;
+}
+
+#supplytransfer .tabs {
+  position: fixed;
+  z-index: 1;
+  width: auto;
+  padding: 10px 10px 0;
+  margin-top: 35px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  box-shadow: 0 1px 2px -2px #1f1f1f;
+}
+
+#supplytransfer .tabs .tab .image,
+#supplytransfer .tabs .tab .image.empty {
+  background-color: #eee;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+#supplytransfer .drawer .listContainer {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 5px 0;
+}
+
+#supplytransfer .listContainer.friendList img {
+  width: 85px;
+  height: 85px;
+  padding-bottom: 5px;
+  border: none;
+  border-radius: 3px;
+}
+
+#supplytransfer .tabs .tab:hover {
+  background: transparent;
+}
+
+.tabContent.item {
+  margin: -5px;
+}
+
+span.mhui-supply-sort-label {
+  color: #000;
+}
+
+#supplytransfer .itemList a.element .itemImage {
+  width: 60px;
+  height: 60px;
+  padding: 5px;
+  overflow: visible;
+}
+
+#supplytransfer .drawer .tabContent {
+  position: relative;
+  height: 100%;
+  max-height: unset;
+}
+
+#supplytransfer .tabs .tab .image .img,
+#supplytransfer .tabs .tab .image {
+  width: 80px;
+  height: 80px;
+}
+
+#supplytransfer .tabs .tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.itemImage .quantity {
+  right: -5px;
+  bottom: -1px;
+  background-color: rgb(255 255 255 / 60%);
+}
+
+#supplytransfer .listContainer a.element.item.pinned .itemImage .quantity {
+  background-color: rgb(174 245 247 / 60%);
 }

--- a/src/modules/better-send-supplies/styles.css
+++ b/src/modules/better-send-supplies/styles.css
@@ -149,11 +149,11 @@
   margin: 10px auto;
 }
 
-.mhui-supply-quick-quantit-max {
+.mhui-supply-quick-quantity-max {
   width: 53px;
 }
 
-.friendList.listContainer {
+#supplytransfer .friendList.listContainer {
   padding-top: 10px;
   margin-top: 10px;
   border-top: 1px solid #ccc;
@@ -249,7 +249,7 @@
   background: transparent;
 }
 
-.tabContent.item {
+#supplytransfer .tabContent.item {
   margin: -5px;
 }
 
@@ -282,7 +282,7 @@ span.mhui-supply-sort-label {
   align-items: center;
 }
 
-.itemImage .quantity {
+#supplytransfer .itemImage .quantity {
   right: -5px;
   bottom: -1px;
   background-color: rgb(255 255 255 / 60%);

--- a/src/modules/better-shops/styles/general.css
+++ b/src/modules/better-shops/styles/general.css
@@ -612,3 +612,12 @@ a.itemPurchaseView-action-buySuperBrie {
 .itemPurchaseView-container.kingsCartItem .itemPurchaseView-content-details {
   height: auto;
 }
+
+.itemPurchaseView-container[data-max-inventory-quantity="1"]::after {
+  position: absolute;
+  top: 17px;
+  right: 5px;
+  z-index: 1;
+  color: #3b3b3b;
+  content: "(Limit " attr(data-max-inventory-quantity) ")";
+}

--- a/src/modules/better-travel/index.js
+++ b/src/modules/better-travel/index.js
@@ -17,10 +17,11 @@ import {
   removeSubmenuItem,
   sessionGet,
   setPage,
-  setTab
+  setTab,
+  travelTo
 } from '@utils';
 
-import { getTravelSetting, saveTravelSetting, travelTo } from './travel-utils';
+import { getTravelSetting, saveTravelSetting } from './travel-utils';
 
 import addReminders from './reminders';
 import travelWindow from './travel-window';

--- a/src/modules/better-travel/index.js
+++ b/src/modules/better-travel/index.js
@@ -549,10 +549,9 @@ const addFavoriteButtonsToTravelPage = async () => {
     }
 
     // Don't add a favorite button to event locations.
-    const isEventLocation = environments.find((environment) => {
+    const isEventLocation = eventEnvironments.find((environment) => {
       return environment.id === type;
     });
-
     if (isEventLocation) {
       return;
     }
@@ -609,6 +608,7 @@ const main = () => {
 };
 
 let environments = [];
+let eventEnvironments = [];
 
 /**
  * Initialize the module.
@@ -623,6 +623,7 @@ const init = async () => {
   addStyles(stylesJoined, 'better-travel');
 
   environments = await getData('environments');
+  eventEnvironments = await getData('environments-events');
 
   main();
 };

--- a/src/modules/better-travel/styles.css
+++ b/src/modules/better-travel/styles.css
@@ -42,7 +42,7 @@
 }
 
 .travelPage-map-zoomContainer {
-  bottom: 300px;
+  bottom: 200px;
   transform: scale(1.5);
 }
 
@@ -340,4 +340,19 @@
 
 .mh-improved-travel-message > div {
   display: none;
+}
+
+.travelPage-map-image-environment-pointer {
+  left: 29px;
+  top: 5px;
+  width: 140px;
+  height: 116px;
+  background-size: cover;
+}
+
+.travelPage-map-image-environment-pointer-image {
+  left: 6px;
+  top: 10px;
+  width: 70px;
+  height: 70px;
 }

--- a/src/modules/better-travel/styles.css
+++ b/src/modules/better-travel/styles.css
@@ -343,16 +343,16 @@
 }
 
 .travelPage-map-image-environment-pointer {
-  left: 29px;
   top: 5px;
+  left: 29px;
   width: 140px;
   height: 116px;
   background-size: cover;
 }
 
 .travelPage-map-image-environment-pointer-image {
-  left: 6px;
   top: 10px;
+  left: 6px;
   width: 70px;
   height: 70px;
 }

--- a/src/modules/better-travel/travel-utils.js
+++ b/src/modules/better-travel/travel-utils.js
@@ -8,21 +8,7 @@ const saveTravelSetting = (settingName, value) => {
   saveSetting(`better-travel.${settingName}`, value);
 };
 
-const travelTo = (location) => {
-  const header = document.querySelector('.mousehuntHeaderView');
-  if (header) {
-    const existing = header.querySelector('.mh-improved-travel-message');
-    if (existing) {
-      existing.remove();
-    }
-
-    makeElement('div', ['mh-improved-travel-message', 'travelPage-map-message'], 'Traveling...', header);
-  }
-  app.pages.TravelPage.travel(location);
-};
-
 export {
   getTravelSetting,
-  saveTravelSetting,
-  travelTo
+  saveTravelSetting
 };

--- a/src/modules/better-travel/travel-utils.js
+++ b/src/modules/better-travel/travel-utils.js
@@ -1,4 +1,4 @@
-import { getSetting, makeElement, saveSetting } from '@utils';
+import { getSetting, saveSetting } from '@utils';
 
 const getTravelSetting = (settingName, defaultValue) => {
   return getSetting(`better-travel.${settingName}`, defaultValue);

--- a/src/modules/better-travel/travel-window.js
+++ b/src/modules/better-travel/travel-window.js
@@ -9,10 +9,11 @@ import {
   isUserTitleAtLeast,
   onDialogHide,
   onEvent,
-  setPage
+  setPage,
+  travelTo
 } from '@utils';
 
-import { getTravelSetting, saveTravelSetting, travelTo } from './travel-utils';
+import { getTravelSetting, saveTravelSetting } from './travel-utils';
 
 import styles from './travel-menu.css';
 

--- a/src/modules/better-ui/hud.js
+++ b/src/modules/better-ui/hud.js
@@ -1,4 +1,4 @@
-import { onTurn } from '@utils';
+import { getFlag, onTurn } from '@utils';
 
 const showFullTitlePercent = async () => {
   const title = document.querySelector('.mousehuntHud-userStat.title');
@@ -49,7 +49,10 @@ const replaceKingdomLink = async () => {
 export default async () => {
   showFullTitlePercent();
   replaceInboxClose();
-  replaceKingdomLink();
+
+  if (! getFlag('no-kingdom-link-replacement')) {
+    replaceKingdomLink();
+  }
 
   onTurn(showFullTitlePercent, 1000);
 };

--- a/src/modules/better-ui/styles/inbox.css
+++ b/src/modules/better-ui/styles/inbox.css
@@ -206,11 +206,6 @@ div#messengerUINotification {
   background-color: #e03a3a;
 }
 
-.giftSelectorView-inbox-footer-label {
-  margin-top: -30px;
-  text-align: left;
-}
-
 #messengerUINotification .notificationMessageList .tab[data-tab="marketplace"] .message .clear-block {
   order: 1;
 }

--- a/src/modules/better-ui/styles/inbox.css
+++ b/src/modules/better-ui/styles/inbox.css
@@ -109,8 +109,8 @@ div#messengerUINotification {
 }
 
 #messengerUINotification .messengerUINotificationClose {
-  top: -15px;
-  right: -5px;
+  top: -14px;
+  right: -12px;
   box-sizing: border-box;
   display: flex;
   align-items: center;

--- a/src/modules/better-ui/styles/legacy.css
+++ b/src/modules/better-ui/styles/legacy.css
@@ -1,0 +1,25 @@
+.headsup .mousehuntHud-userStat.bait:hover .label,
+.headsup .mousehuntHud-userStat.trinket:hover .label,
+.headsup .mousehuntHud-userStat.treasureMap:hover .label {
+  position: relative;
+  top: unset;
+  right: unset;
+  left: unset;
+  width: unset;
+  padding: 0;
+  background: none;
+  mix-blend-mode: normal;
+}
+
+.headsup .mousehuntHud-userStat.treasureMap:hover .label {
+  padding-top: 3px;
+}
+
+.headsup .mousehuntHud-userStat.bait:hover .label {
+  width: 83px;
+}
+
+.headsup .mousehuntHud-userStat:hover .icon {
+  border-color: #ccc;
+  box-shadow: 0 0 3px #ffde00;
+}

--- a/src/modules/better-ui/styles/maintence.css
+++ b/src/modules/better-ui/styles/maintence.css
@@ -1,0 +1,36 @@
+.maintenance-banner {
+  margin-bottom: 20px;
+  line-height: 20px;
+  background-color: #f5f3eb !important;
+  border-color: #ceb7a6 !important;
+  box-shadow: -1px -1px 1px #d3cecb inset;
+}
+
+.maintenance-banner .close {
+  position: absolute;
+  top: -5px;
+  right: 5px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 23px;
+  height: 23px;
+  padding: 5px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: unset;
+  color: #e03a3a;
+  text-align: center;
+  content: "";
+  background: #fff;
+  border: 1px solid #d1d0cf;
+  border-color: #d1d0cf;
+  border-radius: 20px;
+  box-shadow: inset 0 0 3px -1px #d1d0cf;
+}
+
+.maintenance-banner .close:hover {
+  color: #fff;
+  background-color: #e03a3a;
+}

--- a/src/modules/better-ui/styles/tabs.css
+++ b/src/modules/better-ui/styles/tabs.css
@@ -12,17 +12,21 @@
 }
 
 .campPage-tabs-tabRow:hover .campPage-tabs-tabHeader span,
-.campPage-tabs-tabRow:focus .campPage-tabs-tabHeader span,
-.campPage-tabs-tabHeader span {
-  border-bottom: 1px solid #f6f3eb;
+.campPage-tabs-tabRow a.campPage-tabs-tabHeader span {
+  border-bottom: none;
 }
 
-.campPage-tabs-tabHeader.active span,
+.campPage-tabs-tabRow a.campPage-tabs-tabHeader.active span {
+  padding-bottom: 5px;
+  margin-bottom: -1px;
+  border: 1px solid #cbc6bb;
+  border-bottom: none;
+  box-shadow: 0 1px #f5f3eb;
+}
+
 .campPage-tabs-tabRow a.campPage-tabs-tabHeader:hover span,
 .campPage-tabs-tabRow a.campPage-tabs-tabHeader:focus span {
-  border: 1px solid #f7f5ee;
-  border-bottom: none;
-  box-shadow: 0 1px #f7f5ee;
+  margin-bottom: -1px;
 }
 
 /* tab content */
@@ -184,6 +188,10 @@ div#dailyRewardTimer::before {
   border: 1px solid #d3cecb;
   border-radius: 3px;
   box-shadow: -1px 1px 3px 0 #d3cecb inset;
+}
+
+.campPage-tabs-tabContent-larryTip-container {
+  padding-top: 10px;
 }
 
 .campPage-daily-container.daily .campPage-daily-content {

--- a/src/modules/better-ui/userscript-styles/any-trap-any-skin.css
+++ b/src/modules/better-ui/userscript-styles/any-trap-any-skin.css
@@ -1,0 +1,52 @@
+#custom-skins-flex {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+}
+
+.buttonstyle {
+  position: relative;
+  display: block;
+  width: 100px;
+  height: 25px;
+  margin: 5px;
+  line-height: 25px;
+  color: #926944;
+  background-color: #f6f3eb !important;
+  border: 1px solid #d3cecb;
+  border-radius: 4px;
+  box-shadow: -1px 1px 3px #d3cecb inset;
+}
+
+.buttonstyle:hover {
+  color: #926944;
+  background-color: #fdfaf2 !important;
+}
+
+/* activated button */
+.buttonstyle[style*="rgb(34, 139, 34);"] {
+  color: #fff;
+  background-color: #5ccd5d !important;
+}
+
+.buttonstyle[style*="rgb(34, 139, 34);"]:hover {
+  background-color: #2e942f !important;
+}
+
+#trap-skin-button::after,
+#base-skin-button::after {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  content: "Toggle Trap";
+}
+
+#base-skin-button::after {
+  content: "Toggle Base";
+}
+
+#wb-steal {
+  margin-left: 10px;
+}

--- a/src/modules/custom-shield/index.js
+++ b/src/modules/custom-shield/index.js
@@ -64,8 +64,6 @@ const changeShield = () => {
     const remove = [
       ...lastShield,
       'mhui-custom-shield',
-      'birthday',
-      'year16', // TODO: remove this after the event.
     ];
 
     remove.forEach((className) => {

--- a/src/modules/custom-shield/settings/index.js
+++ b/src/modules/custom-shield/settings/index.js
@@ -56,6 +56,7 @@ export default async () => {
       value: 'group',
       options: [
         { name: 'Current Title ', value: 'title' },
+        { seperator: true },
         { name: 'Novice', value: 'title.novice' },
         { name: 'Recruit', value: 'title.recruit' },
         { name: 'Apprentice', value: 'title.apprentice' },

--- a/src/modules/experiments/index.js
+++ b/src/modules/experiments/index.js
@@ -43,6 +43,14 @@ const experiments = [
     load: legacyHud,
   },
   {
+    id: 'experiments.legacy-hud-only-menu',
+    title: 'Legacy HUD: Menu only',
+  },
+  {
+    id: 'experiments.legacy-hud-only-stats',
+    title: 'Legacy HUD: Stats bar only',
+  },
+  {
     id: 'experiments.legacy-hud-tweaks',
     title: 'Legacy HUD Tweaks',
     load: legacyHudTweaks,

--- a/src/modules/experiments/index.js
+++ b/src/modules/experiments/index.js
@@ -10,6 +10,7 @@ import newSettingsStylesColumns from './modules/new-settings-styles-columns';
 import raffle from './modules/raffle';
 import replaceFavicon from './modules/replace-favicon';
 import shieldGoesToCamp from './modules/shield-goes-to-camp';
+import stickyPopups from './modules/sticky-popups';
 import trollMode from './modules/troll-mode';
 import uniqueLootCount from './modules/unique-loot-count';
 
@@ -56,6 +57,11 @@ const experiments = [
     id: 'experiments.raffle',
     title: 'Return Raffles button',
     load: raffle,
+  },
+  {
+    id: 'experiments.sticky-popups',
+    title: 'Sticky Popups',
+    load: stickyPopups,
   },
   {
     id: 'experiments.lol-gottem',

--- a/src/modules/experiments/index.js
+++ b/src/modules/experiments/index.js
@@ -2,13 +2,16 @@ import { getSetting } from '@utils';
 
 import bigTimer from './modules/big-timer';
 import codexAtBottom from './modules/codex-at-bottom';
+import delayedMenus from './modules/delayed-menus';
 import journalTags from './modules/journal-tags';
 import legacyHud from './modules/legacy-hud';
 import legacyHudTweaks from './modules/legacy-hud-tweaks';
 import newSettingsStylesColumns from './modules/new-settings-styles-columns';
 import raffle from './modules/raffle';
 import replaceFavicon from './modules/replace-favicon';
+import shieldGoesToCamp from './modules/shield-goes-to-camp';
 import trollMode from './modules/troll-mode';
+import uniqueLootCount from './modules/unique-loot-count';
 
 const experiments = [
   {
@@ -18,10 +21,20 @@ const experiments = [
     load: bigTimer,
   },
   {
+    id: 'experiments.shield-goes-to-camp',
+    title: 'Clicking shield goes to camp if not already there',
+    load: shieldGoesToCamp
+  },
+  {
     id: 'experiments.codex-at-bottom',
     title: 'Codex at bottom',
     description: 'Moves the Codex section to the bottom of the trap selector',
     load: codexAtBottom,
+  },
+  {
+    id: 'experiments.delayed-menus',
+    title: 'Delayed Menus',
+    load: delayedMenus,
   },
   {
     id: 'experiments.legacy-hud',
@@ -48,6 +61,11 @@ const experiments = [
     id: 'experiments.lol-gottem',
     title: 'Troll mode',
     load: trollMode,
+  },
+  {
+    id: 'experiments.unique-loot-count',
+    title: 'Unique loot count in progress log',
+    load: uniqueLootCount,
   },
   {
     id: 'better-journal.journal-tags',

--- a/src/modules/experiments/modules/big-timer/index.js
+++ b/src/modules/experiments/modules/big-timer/index.js
@@ -9,8 +9,10 @@ const toggleBigTimer = () => {
     return;
   }
 
+  let isBigTimer = timer.classList.contains('big-timer');
   timer.addEventListener('click', () => {
-    timer.classList.toggle('big-timer');
+    isBigTimer = ! isBigTimer;
+    timer.classList.toggle('big-timer', isBigTimer);
   });
 };
 

--- a/src/modules/experiments/modules/big-timer/legacy-styles.css
+++ b/src/modules/experiments/modules/big-timer/legacy-styles.css
@@ -8,12 +8,12 @@
 
 .big-timer.huntersHornView__timer.huntersHornView__timer.countdown {
   position: absolute;
-  top: 63px;
-  left: 265px;
+  top: 60px;
+  left: 270px;
   z-index: 100;
   padding: 2px;
   background-color: #d9c9a0;
   border-radius: 5px;
-  box-shadow: 0 -1px 0 0 #ded9c3;
-  transform: scale(2.2);
+  box-shadow: 0 -1px #ded9c3;
+  transform: scale(2.6);
 }

--- a/src/modules/experiments/modules/delayed-menus/index.js
+++ b/src/modules/experiments/modules/delayed-menus/index.js
@@ -3,5 +3,5 @@ import { addStyles } from '@utils';
 import styles from './styles.css';
 
 export default async () => {
-  addStyles(styles, 'journal-tags');
+  addStyles(styles, 'delayed-menus');
 };

--- a/src/modules/experiments/modules/delayed-menus/styles.css
+++ b/src/modules/experiments/modules/delayed-menus/styles.css
@@ -1,0 +1,4 @@
+.mousehuntHud-menu ul li ul {
+  transform-origin: top;
+  animation: mh-improved-in-scale-y 0.15s 1 backwards cubic-bezier(0.4, 0, 1, 1);
+}

--- a/src/modules/experiments/modules/journal-tags/styles.css
+++ b/src/modules/experiments/modules/journal-tags/styles.css
@@ -1,3 +1,4 @@
+.journal .content .catchsuccessloot::after,
 .journal .content .attractionfailure::after,
 .journal .content .catchfailure::after,
 .journal .content .luckycatchsuccess::after,
@@ -19,6 +20,31 @@
   border-radius: 3px;
   opacity: 0;
   transition: 0.2s;
+}
+
+.journal .content .catchsuccessloot:hover::after,
+.journal .content .attractionfailure:hover::after,
+.journal .content .catchfailure:hover::after,
+.journal .content .luckycatchsuccess:hover::after,
+.journal .content .passive:hover::after,
+.journal .content .linked:hover::after {
+  opacity: 1;
+}
+
+.journal .content .bonuscatchsuccess::after,
+.journal .content .bonuscatchfailure::after {
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.journal .content .bonuscatchsuccess:hover::after,
+.journal .content .bonuscatchfailure:hover::after {
+  opacity: 1;
+}
+
+.journal .content .catchsuccessloot::after {
+  content: "Catch";
+  background: #53891b;
 }
 
 .journal .content .catchfailure::after {
@@ -62,23 +88,4 @@
 
 .journal .content .passive.catchfailure::after {
   content: "Trap Check · FTC";
-}
-
-.journal .content .attractionfailure:hover::after,
-.journal .content .catchfailure:hover::after,
-.journal .content .luckycatchsuccess:hover::after,
-.journal .content .passive:hover::after,
-.journal .content .linked:hover::after {
-  opacity: 1;
-}
-
-.journal .content .bonuscatchsuccess::after,
-.journal .content .bonuscatchfailure::after {
-  opacity: 0;
-  transition: opacity 0.3s;
-}
-
-.journal .content .bonuscatchsuccess:hover::after,
-.journal .content .bonuscatchfailure:hover::after {
-  opacity: 1;
 }

--- a/src/modules/experiments/modules/legacy-hud-tweaks/styles.css
+++ b/src/modules/experiments/modules/legacy-hud-tweaks/styles.css
@@ -39,7 +39,8 @@
 }
 
 .headsup .hudstatlist:nth-child(5) ul li:nth-child(1),
-.headsup .hudstatlist:nth-child(5) ul li:nth-child(2) {
+.headsup .hudstatlist:nth-child(5) ul li:nth-child(2),
+.headsup .hudstatlist:nth-child(5) ul li:nth-child(3) {
   display: flex;
   justify-content: space-between;
   width: 150px;

--- a/src/modules/experiments/modules/legacy-hud/index.js
+++ b/src/modules/experiments/modules/legacy-hud/index.js
@@ -1,6 +1,7 @@
-import { addStyles, makeElement } from '@utils';
+import { addStyles, getSetting, makeElement } from '@utils';
 
-import styles from './styles.css';
+import menuStyles from './menu.css';
+import statsStyles from './stats.css';
 
 const getMapText = () => {
   if (user?.quests?.QuestRelicHunter?.maps?.length) {
@@ -17,7 +18,7 @@ const getMapText = () => {
 };
 
 const getEquippedStat = (type, label, id, name, quantity) => {
-  return `<li class="mousehuntHud-userStat ${type}" data-item-id="${id}">
+  return `<li class="mousehuntHud-userStat ${type}" data-item-id="${id}" data-itemId="${id}">
     <span class="hudstatlabel">${label}:</span>
     <span id="hud_${type}" class="hudstatvalue">
       <a href="#" class="label" onclick="hg.utils.PageUtil.setPage('Inventory', {tab:'traps', sub_tab:'${type}'}); return false;">
@@ -72,7 +73,7 @@ const getLegacyHudHtml = () => {
     </div>
     <div id="cheeseped" class="cheeseped">
       <a href="#" class="baiticon" target="_parent" onclick="hg.utils.PageUtil.setPage('Inventory', {tab:'cheese'}); return false;">
-        <img id="hud_baitIcon" src="${user?.bait_thumb}" border="0" title="${user?.bait_name} ${user?.bait_quantity.toLocaleString()}">
+        <img id="hud_baitIcon" src="${user?.bait_thumb}" border="0">
       </a>
     </div>
     <div class="hudstatlist legacyFix">
@@ -86,7 +87,7 @@ const getLegacyHudHtml = () => {
       <ul>
         ${getStat('gold', 'Gold', user?.gold.toLocaleString())}
         ${getStat('points', 'Points', user?.points.toLocaleString())}
-        ${getEquippedStat('bait', 'Bait', user?.bait_item_id, user?.bait_name, user?.bait_quantity.toLocaleString())}
+        ${getEquippedStat('bait', 'Bait', user?.bait_item_id, user?.bait_name, user?.bait_quantity)}
       </ul>
     </div>
     <div class="hudstatlist">
@@ -169,7 +170,9 @@ const makeOldMenu = () => {
       kingdomMenu.parentNode.insertBefore(lore, kingdomMenu.nextSibling);
     }
   }
+};
 
+const replaceStatsBar = () => {
   const hudStats = document.querySelector('.headsUpDisplayView-stats');
   if (hudStats) {
     const existingLegacyHud = document.querySelector('.mh-legacy-mode-hud');
@@ -179,10 +182,29 @@ const makeOldMenu = () => {
       hudStats.parentNode.insertBefore(legacyHud, hudStats.nextSibling);
     }
   }
+
+  const oldStats = document.querySelector('.mousehuntHud-userStatBar');
+  if (oldStats) {
+    oldStats.remove();
+  }
 };
 
 export default async () => {
-  addStyles(styles, 'experiment-legacy-hud');
+  const stylesToAdd = [];
 
-  makeOldMenu();
+  const loadMenu = getSetting('experiments.legacy-hud-only-menu', false);
+  const loadStats = getSetting('experiments.legacy-hud-only-stats', false);
+  const loadBoth = loadMenu === loadStats;
+
+  if (loadMenu || loadBoth) {
+    stylesToAdd.push(menuStyles);
+    makeOldMenu();
+  }
+
+  if (loadStats || loadBoth) {
+    stylesToAdd.push(statsStyles);
+    replaceStatsBar();
+  }
+
+  addStyles(stylesToAdd, 'experiment-legacy-hud');
 };

--- a/src/modules/experiments/modules/legacy-hud/menu.css
+++ b/src/modules/experiments/modules/legacy-hud/menu.css
@@ -1,4 +1,3 @@
-.mousehuntHud-userStatBar,
 .mousehuntHud-environment,
 .mousehuntHud-menu .camp,
 .mousehuntHud-menu .friends .team,
@@ -17,13 +16,4 @@
 .mousehuntHud-menu .kingdom .merch_store,
 .mh-legacy-mode-remove {
   display: none;
-}
-
-.headsup .cheeseped a.baiticon img {
-  height: 50px;
-}
-
-.headsup .cheeseped a.baiticon {
-  top: -13px;
-  right: 4px;
 }

--- a/src/modules/experiments/modules/legacy-hud/stats.css
+++ b/src/modules/experiments/modules/legacy-hud/stats.css
@@ -1,0 +1,8 @@
+.headsup .cheeseped a.baiticon img {
+  height: 45px;
+}
+
+.headsup .cheeseped a.baiticon {
+  top: -4px;
+  right: 2px;
+}

--- a/src/modules/experiments/modules/replace-favicon/index.js
+++ b/src/modules/experiments/modules/replace-favicon/index.js
@@ -1,13 +1,33 @@
-import { onTurn } from '@utils';
+import { onTurn, setMultipleTimeout } from '@utils';
 
 const replace = () => {
-  const favicon = document.querySelector('link[rel="SHORTCUT ICON"]'); // idk why it's all caps on the site, but it is.
+  const favicon = document.querySelector('#favicon');
   if (favicon) {
-    favicon.href = 'https://www.mousehuntgame.com/images/ui/elements/golden_shield_page_shield_320.png';
+    favicon.href = 'https://i.mouse.rip/mh-icons/favicon.ico';
   }
 };
 
+const add = () => {
+  const icons = [
+    { rel: 'apple-touch-icon', sizes: '180x180', href: 'https://i.mouse.rip/mh-icons/apple-touch-icon.png' },
+    { rel: 'icon', type: 'image/png', sizes: '32x32', href: 'https://i.mouse.rip/mh-icons/favicon-32x32.png' },
+    { rel: 'icon', type: 'image/png', sizes: '16x16', href: 'https://i.mouse.rip/mh-icons/favicon-16x16.png' },
+    { rel: 'mask-icon', href: 'https://i.mouse.rip/mh-icons/safari-pinned-tab.svg', color: '#cfae00' },
+  ];
+
+  icons.forEach((icon) => {
+    const link = document.createElement('link');
+    for (const key in icon) {
+      link.setAttribute(key, icon[key]);
+    }
+    document.head.append(link);
+  });
+};
+
 export default async () => {
+  add();
   replace();
-  onTurn(replace, 2500);
+  onTurn(() => {
+    setMultipleTimeout(replace, [1000, 2000, 3000, 4000, 5000]);
+  });
 };

--- a/src/modules/experiments/modules/replace-favicon/index.js
+++ b/src/modules/experiments/modules/replace-favicon/index.js
@@ -9,5 +9,5 @@ const replace = () => {
 
 export default async () => {
   replace();
-  onTurn(replace, 500);
+  onTurn(replace, 2500);
 };

--- a/src/modules/experiments/modules/shield-goes-to-camp/index.js
+++ b/src/modules/experiments/modules/shield-goes-to-camp/index.js
@@ -1,0 +1,16 @@
+import { getCurrentPage, onNavigation } from '@utils';
+
+const campToggle = () => {
+  const shield = document.querySelector('.mousehuntHud-shield');
+  if (shield) {
+    if ('camp' === getCurrentPage()) {
+      shield.setAttribute('onclick', 'hg.utils.PageUtil.showHunterProfile()');
+    } else {
+      shield.setAttribute('onclick', 'hg.utils.PageUtil.setPage("camp")');
+    }
+  }
+};
+
+export default async () => {
+  onNavigation(campToggle);
+};

--- a/src/modules/experiments/modules/sticky-popups/index.js
+++ b/src/modules/experiments/modules/sticky-popups/index.js
@@ -1,0 +1,7 @@
+import { addStyles } from '@utils';
+
+import styles from './styles.css';
+
+export default async () => {
+  addStyles(styles, 'sticky-popups');
+};

--- a/src/modules/experiments/modules/sticky-popups/styles.css
+++ b/src/modules/experiments/modules/sticky-popups/styles.css
@@ -1,0 +1,5 @@
+#overlayPopup {
+  position: sticky;
+  top: 10vh !important;
+  overflow: hidden;
+}

--- a/src/modules/experiments/modules/unique-loot-count/index.js
+++ b/src/modules/experiments/modules/unique-loot-count/index.js
@@ -1,0 +1,21 @@
+import { makeElement, onDialogShow, setMultipleTimeout } from '@utils';
+
+const addUniqueLootCount = () => {
+  const existing = document.querySelector('#overlayPopup.hunting_summary .lootContainer .label .uniqueLootCount');
+  if (existing) {
+    return;
+  }
+
+  const lootTitle = document.querySelector('#overlayPopup.hunting_summary .lootContainer .label');
+  if (! lootTitle) {
+    return;
+  }
+
+  const loots = document.querySelectorAll('#overlayPopup.hunting_summary .lootContainer a');
+
+  makeElement('span', 'uniqueLootCount', `(${loots.length} unique)`, lootTitle);
+};
+
+export default async () => {
+  onDialogShow('hunting_summary', () => setMultipleTimeout(addUniqueLootCount, 500, 1000, 3000));
+};

--- a/src/modules/experiments/modules/unique-loot-count/index.js
+++ b/src/modules/experiments/modules/unique-loot-count/index.js
@@ -1,21 +1,34 @@
-import { makeElement, onDialogShow, setMultipleTimeout } from '@utils';
+import { addStyles, makeElement, onDialogShow, setMultipleTimeout } from '@utils';
 
-const addUniqueLootCount = () => {
-  const existing = document.querySelector('#overlayPopup.hunting_summary .lootContainer .label .uniqueLootCount');
+import styles from './styles.css';
+
+const updateSection = async (selector) => {
+  const section = document.querySelector(`#overlayPopup.hunting_summary .${selector} .label`);
+  if (! section) {
+    return;
+  }
+
+  const existing = section.querySelector('.uniqueLootCount');
   if (existing) {
     return;
   }
 
-  const lootTitle = document.querySelector('#overlayPopup.hunting_summary .lootContainer .label');
-  if (! lootTitle) {
-    return;
-  }
+  const loots = section.querySelectorAll('a');
+  makeElement('span', 'uniqueLootCount', `(${loots.length} unique)`, section);
+};
 
-  const loots = document.querySelectorAll('#overlayPopup.hunting_summary .lootContainer a');
+const addUniqueLootCount = async () => {
+  const sections = [
+    'environmentContainer',
+    'baitContainer',
+    'lootContainer',
+  ];
 
-  makeElement('span', 'uniqueLootCount', `(${loots.length} unique)`, lootTitle);
+  sections.forEach((section) => updateSection(section));
 };
 
 export default async () => {
+  addStyles(styles, 'unique-loot-count');
+
   onDialogShow('hunting_summary', () => setMultipleTimeout(addUniqueLootCount, 500, 1000, 3000));
 };

--- a/src/modules/experiments/modules/unique-loot-count/styles.css
+++ b/src/modules/experiments/modules/unique-loot-count/styles.css
@@ -1,0 +1,3 @@
+.uniqueLootCount {
+  margin-left: 5px;
+}

--- a/src/modules/fixes/styles/tabs.css
+++ b/src/modules/fixes/styles/tabs.css
@@ -22,17 +22,17 @@ a.mousehuntHud-page-tabHeader.collectibles span {
 }
 
 .mousehuntHud-page-tabHeader {
-  height: 29px;
+  height: 30px;
 }
 
 .mousehuntHud-page-tabHeader span {
-  height: 17px;
-  margin-top: 4px;
+  height: 16px;
+  margin-top: 5px;
 }
 
 .mousehuntHud-page-tabHeader.active span,
 .mousehuntHud-page-tabHeader:hover span {
-  padding-bottom: 7px;
+  padding-bottom: 8px;
   margin-top: 0;
   border-bottom: none;
 }

--- a/src/modules/fixes/styles/tabs.css
+++ b/src/modules/fixes/styles/tabs.css
@@ -26,7 +26,7 @@ a.mousehuntHud-page-tabHeader.collectibles span {
 }
 
 .mousehuntHud-page-tabHeader span {
-  height: 16px;
+  height: 17px;
   margin-top: 4px;
 }
 

--- a/src/modules/global-styles/styles/animations.css
+++ b/src/modules/global-styles/styles/animations.css
@@ -11,288 +11,143 @@
   opacity: 0;
 }
 
+/* stylelint-disable rule-empty-line-before */
+/* stylelint-disable prettier/prettier */
+/* stylelint-disable stylistic/block-opening-brace-space-before */
+/* stylelint-disable declaration-block-single-line-max-declarations */
 @keyframes mh-improved-fade-slightly {
-  0% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0.75;
-  }
-
-  100% {
-    opacity: 1;
-  }
+  0%   { opacity: 1; }
+  50%  { opacity: 0.75; }
+  100% { opacity: 1; }
 }
 
 @keyframes mh-improved-fade-in {
-  0% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
+  0%   { opacity: 0; }
+  100% { opacity: 1; }
 }
 
 @keyframes mh-improved-fade-out {
-  0% {
-    opacity: 1;
-  }
-
-  100% {
-    opacity: 0;
-  }
+  0%   { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 @keyframes mh-improved-in-from-left {
-  from {
-    opacity: 0;
-    transform: translate3d(-100%, 0, 0);
-  }
-
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
+  0%   { opacity: 0; transform: translate3d(-100%, 0, 0); }
+  100% { opacity: 1; transform: translate3d(0, 0, 0); }
 }
 
 @keyframes mh-improved-in-from-top {
-  from {
-    visibility: visible;
-    transform: translate3d(0, -100%, 0);
-  }
-
-  to {
-    transform: translate3d(0, 0, 0);
-  }
+  0%   { visibility: visible; transform: translate3d(0, -100%, 0); }
+  100% { transform: translate3d(0, 0, 0); }
 }
 
 @keyframes mh-improved-in-scale {
-  0% {
-    opacity: 0;
-    transform: scale(0);
-  }
+  0%   { opacity: 0; transform: scale(0); }
+  100% { opacity: 1; transform: scale(1); }
+}
 
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
+@keyframes mh-improved-in-scale-y {
+  0%   { opacity: 0; transform: scaleY(0); }
+  100% { opacity: 1; transform: scaleY(1); }
 }
 
 @keyframes mh-improved-shake {
-  0% {
-    transform: rotate(0deg);
-  }
-
-  25% {
-    transform: rotate(5deg);
-  }
-
-  50% {
-    transform: rotate(-5deg);
-  }
-
-  75% {
-    transform: rotate(5deg);
-  }
-
-  100% {
-    transform: rotate(0deg);
-  }
+  0%   { transform: rotate(0deg); }
+  25%  { transform: rotate(5deg); }
+  50%  { transform: rotate(-5deg); }
+  75%  { transform: rotate(5deg); }
+  100% { transform: rotate(0deg); }
 }
 
 @keyframes mh-improved-shake-scaled {
-  0% {
-    transform: scale(1.2) rotate(0deg);
-  }
-
-  25% {
-    transform: scale(1.2) rotate(5deg);
-  }
-
-  50% {
-    transform: scale(1.2) rotate(-5deg);
-  }
-
-  75% {
-    transform: scale(1.2) rotate(5deg);
-  }
-
-  100% {
-    transform: scale(1.2) rotate(0deg);
-  }
+  0%   { transform: scale(1.2) rotate(0deg); }
+  25%  { transform: scale(1.2) rotate(5deg); }
+  50%  { transform: scale(1.2) rotate(-5deg); }
+  75%  { transform: scale(1.2) rotate(5deg); }
+  100% { transform: scale(1.2) rotate(0deg); }
 }
 
 @keyframes mh-improved-shake-light {
-  0% {
-    transform: rotate(0deg);
-  }
-
-  25% {
-    transform: rotate(-5deg);
-  }
-
-  75% {
-    transform: rotate(5deg);
-  }
-
-  100% {
-    transform: rotate(0deg);
-  }
+  0%   { transform: rotate(0deg); }
+  25%  { transform: rotate(-5deg); }
+  75%  { transform: rotate(5deg); }
+  100% { transform: rotate(0deg); }
 }
 
 @keyframes mh-improved-spin {
-  0% {
-    transform: rotate(0deg);
-  }
-
-  100% {
-    transform: rotate(360deg);
-  }
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 
 @keyframes mh-improved-spin-flipped {
-  0% {
-    transform: scaleX(-1) rotate(0deg);
-  }
-
-  100% {
-    transform: scaleX(-1) rotate(360deg);
-  }
+  0%   { transform: scaleX(-1) rotate(0deg); }
+  100% { transform: scaleX(-1) rotate(360deg); }
 }
 
 @keyframes mh-improved-spin-large {
-  0% {
-    transform: scale(2) rotate(0deg);
-  }
-
-  100% {
-    transform: scale(2) rotate(360deg);
-  }
+  0%   { transform: scale(2) rotate(0deg); }
+  100% { transform: scale(2) rotate(360deg); }
 }
 
 @keyframes mh-improved-spin-large-flipped {
-  0% {
-    transform: scale(-2, 2) rotate(0deg);
-  }
-
-  100% {
-    transform: scale(-2, 2) rotate(360deg);
-  }
+  0%   { transform: scale(-2, 2) rotate(0deg); }
+  100% { transform: scale(-2, 2) rotate(360deg); }
 }
 
 @keyframes mh-improved-right-to-left {
-  0% {
-    right: 100%;
-  }
-
-  100% {
-    right: 0;
-  }
+  0%   { right: 100%; }
+  100% { right: 0; }
 }
 
 @keyframes mh-improved-background-slide {
-  0% {
-    background-position: left;
-  }
-
-  50% {
-    background-position: right;
-  }
-
-  100% {
-    background-position: left;
-  }
+  0%   { background-position: left; }
+  50%  { background-position: right; }
+  100% { background-position: left; }
 }
 
 @keyframes mh-improved-bounce-and-stretch {
-  0% {
-    transform: scaleX(1) translateX(-10px);
-  }
-
-  60% {
-    transform: scaleX(1);
-  }
-
-  75% {
-    transform: scaleX(0.98);
-  }
-
-  90% {
-    transform: scaleX(0.999);
-  }
+  0%  { transform: scaleX(1) translateX(-10px); }
+  60% { transform: scaleX(1); }
+  75% { transform: scaleX(0.98); }
+  90% { transform: scaleX(0.999); }
 }
 
 @keyframes mh-improved-hue-rotate {
-  0% {
-    filter: hue-rotate(0deg);
-  }
-
-  50% {
-    filter: hue-rotate(360deg);
-  }
-
-  100% {
-    filter: hue-rotate(0deg);
-  }
+  0%   { filter: hue-rotate(0deg); }
+  50%  { filter: hue-rotate(360deg); }
+  100% { filter: hue-rotate(0deg); }
 }
 
 @keyframes mh-improved-hue-rotate-and-scale {
-  0% {
-    filter: hue-rotate(0deg);
-    transform: scale(1);
-  }
-
-  50% {
-    filter: hue-rotate(360deg);
-    transform: scale(1.5);
-  }
-
-  100% {
-    filter: hue-rotate(0deg);
-    transform: scale(1);
-  }
+  0%   { filter: hue-rotate(0deg); transform: scale(1); }
+  50%  { filter: hue-rotate(360deg); transform: scale(1.5); }
+  100% { filter: hue-rotate(0deg); transform: scale(1); }
 }
 
 @keyframes mh-improved-glow {
-  0% {
-    filter: brightness(1);
-  }
-
-  50% {
-    filter: brightness(1.1);
-  }
-
-  100% {
-    filter: brightness(1);
-  }
+  0%   { filter: brightness(1); }
+  50%  { filter: brightness(1.1); }
+  100% { filter: brightness(1); }
 }
 
 @keyframes mh-improved-dim {
-  0% {
-    filter: brightness(1);
-  }
-
-  50% {
-    filter: brightness(0.8);
-  }
-
-  100% {
-    filter: brightness(1);
-  }
+  0%   { filter: brightness(1); }
+  50%  { filter: brightness(0.8); }
+  100% { filter: brightness(1); }
 }
 
 @keyframes mh-improved-scale-large {
-  0% {
-    transform: scale(1);
-  }
-
-  50% {
-    transform: scale(2.7);
-  }
-
-  100% {
-    transform: scale(1);
-  }
+  0%   { transform: scale(1); }
+  50%  { transform: scale(2.7); }
+  100% { transform: scale(1); }
 }
+
+@keyframes mh-improved-fade-busy {
+  0%   { pointer-events: none; opacity: 0.5; }
+  100% { pointer-events: all; opacity: 1; }
+}
+
+/* stylelint-enable rule-empty-line-before */
+/* stylelint-enable prettier/prettier */
+/* stylelint-enable stylistic/block-opening-brace-space-before */
+/* stylelint-enable declaration-block-single-line-max-declarations */

--- a/src/modules/global-styles/styles/general.css
+++ b/src/modules/global-styles/styles/general.css
@@ -25,3 +25,21 @@ code {
 .pageSidebarView .fb-page {
   order: 1000;
 }
+
+.support-link {
+  padding: 10px;
+  background: #8dff7d;
+  border-radius: 10px;
+  box-shadow: -1px -1px 1px #ccc inset;
+}
+
+.support-link p {
+  margin-top: 0;
+  font-size: 14px;
+  font-weight: 900;
+}
+
+.support-link a {
+  font-size: 16px;
+  font-weight: 900;
+}

--- a/src/modules/image-upscaling/styles.css
+++ b/src/modules/image-upscaling/styles.css
@@ -77,8 +77,9 @@
 }
 
 .mousehuntHud-userStat .icon {
-  width: 27px;
-  height: 27px;
+  width: 28px;
+  height: 28px;
+  background-size: 100%;
   border: none;
   box-shadow: none;
 }

--- a/src/modules/inventory-open-all-but-one/index.js
+++ b/src/modules/inventory-open-all-but-one/index.js
@@ -27,7 +27,7 @@ const replaceOpenAction = () => {
           maxQuantity = Number.parseInt(quantityEl.innerText.split('/')[1].trim(), 10);
         }
 
-        const quantity = maxQuantity - 1;
+        const quantity = maxQuantity > 200 ? 200 : maxQuantity - 1;
 
         const quantityInput = getQuantityInput();
         if (quantityInput) {

--- a/src/modules/location-dashboard/index.js
+++ b/src/modules/location-dashboard/index.js
@@ -9,7 +9,8 @@ import {
   makeElement,
   onEvent,
   onRequest,
-  sessionSet
+  sessionSet,
+  travelTo
 } from '@utils';
 
 import { getData } from '@utils/data';
@@ -374,17 +375,28 @@ const makeLocationMarkup = (id, name, progress, appendTo, quests) => {
   // Name & travel links
   const locationImageWrapper = makeElement('div', 'locationImageWrapper');
   // get the image for the location
-  const image = environments.find((env) => env.id === id);
-  if (image.image) {
+  const environment = environments.find((env) => env.id === id);
+  if (environment.image) {
     const locationImage = makeElement('img', 'locationImage');
-    locationImage.setAttribute('src', image.image);
+    locationImage.setAttribute('src', environment.image);
 
     locationImageWrapper.append(locationImage);
   }
 
+  locationImageWrapper.addEventListener('click', async () => {
+    travelTo(environment.id);
+  });
+
   locationWrapper.append(locationImageWrapper);
 
-  makeElement('div', 'locationName', name, locationWrapper);
+  const nameEl = makeElement('div', 'locationName', name);
+
+  nameEl.addEventListener('click', async () => {
+    travelTo(environment.id);
+  });
+
+  locationWrapper.append(nameEl);
+
   makeElement('div', 'locationProgress', markup, locationWrapper);
 
   appendTo.append(locationWrapper);

--- a/src/modules/location-dashboard/location/bountiful-beanstalk.js
+++ b/src/modules/location-dashboard/location/bountiful-beanstalk.js
@@ -10,30 +10,42 @@ export default (quests) => {
     return '';
   }
 
-  if (quests?.QuestBountifulBeanstalk?.in_castle) {
-    // Castle text
-    const room = quests?.QuestBountifulBeanstalk?.castle?.current_room?.name || '';
-    const floor = quests?.QuestBountifulBeanstalk?.castle?.current_floor?.name || false;
-    const huntsRemaining = quests?.QuestBountifulBeanstalk?.castle?.hunts_remaining_text || '';
-    const isBoss = quests?.QuestBountifulBeanstalk?.castle?.is_boss_encounter || false;
-    const isChase = quests?.QuestBountifulBeanstalk?.castle?.is_boss_chase || false;
-    const noise = quests?.QuestBountifulBeanstalk?.castle?.noise_level || 0;
-    const noiseFormatted = noise.toLocaleString();
-    const maxNoise = quests?.QuestBountifulBeanstalk?.castle?.max_noise_level || 0;
-    const maxNoiseFormatted = maxNoise.toLocaleString();
-    const embellishments = quests?.QuestBountifulBeanstalk?.embellishments.map((item) => {
-      return item.is_active ? item.name : null;
-    }).filter((item) => item !== null);
+  if (! quests?.QuestBountifulBeanstalk?.in_castle) {
+    const room = quests?.QuestBountifulBeanstalk?.beanstalk?.current_zone?.name || '';
+    const huntsRemaining = quests?.QuestBountifulBeanstalk?.beanstalk?.hunts_remaining_text || '';
+    const isBoss = quests?.QuestBountifulBeanstalk?.beanstalk?.is_boss_encounter || false;
 
-    const noiseString = isBoss ? 'Boss' : (isChase ? 'Chase' : `Noise: ${noiseFormatted}/${maxNoiseFormatted}`);
-    const floorText = floor ? `(${floor.replace(/ Floor$/, '')})` : '';
-
-    return `${room} ${floorText}<div class="stats">${noiseString} · ${huntsRemaining}</div><div class="embelishments">${embellishments.join(', ')}</div>`;
+    return `${room} (Beanstalk) <div class="stats">${isBoss ? 'At Boss · ' : ''}${huntsRemaining}</div>`;
   }
 
-  const room = quests?.QuestBountifulBeanstalk?.beanstalk?.current_zone?.name || '';
-  const huntsRemaining = quests?.QuestBountifulBeanstalk?.beanstalk?.hunts_remaining_text || '';
-  const isBoss = quests?.QuestBountifulBeanstalk?.beanstalk?.is_boss_encounter || false;
+  const huntsRemaining = quests?.QuestBountifulBeanstalk?.castle?.hunts_remaining_text || '';
+  const isBoss = quests?.QuestBountifulBeanstalk?.castle?.is_boss_encounter || false;
+  const isChase = quests?.QuestBountifulBeanstalk?.castle?.is_boss_chase || false;
+  const noise = quests?.QuestBountifulBeanstalk?.castle?.noise_level || 0;
+  const maxNoise = quests?.QuestBountifulBeanstalk?.castle?.max_noise_level || 0;
 
-  return `${room} (Beanstalk) <div class="stats">${isBoss ? 'At Boss' : ''} · ${huntsRemaining}</div>`;
+  const roomQuality = quests?.QuestBountifulBeanstalk?.castle?.current_room?.type
+    .replace('_room', '')
+    .split('_')
+    .pop()
+    .trim();
+
+  const roomName = quests?.QuestBountifulBeanstalk?.castle?.current_room?.name
+    .replace(' Room', '')
+    .replace(`${roomQuality.charAt(0).toUpperCase() + roomQuality.slice(1).toLowerCase()} `, '')
+    .trim();
+
+  const noiseString = isBoss ? 'Boss' : (isChase ? 'Chase' : `♪ ${noise.toLocaleString()}/${maxNoise.toLocaleString()}`);
+
+  const embellishmentsText = quests?.QuestBountifulBeanstalk?.embellishments
+    .filter((item) => item.is_active)
+    .map((item) => `<span class="tile ${item.type}"></span>`);
+
+  let returnText = '<div class="dashboard-bb">';
+  returnText += `<div class="dashboard-bb-wrap room-name"><span class="tile ${roomQuality}"></span><div class="name">${roomName}</div>`;
+  returnText += `<div class="dashboard-bb-wrap embellishments">${embellishmentsText.join('')}</div>`;
+  returnText += '</div>';
+  returnText += `<div class="stats">${noiseString} · ${huntsRemaining}</div>`;
+
+  return returnText;
 };

--- a/src/modules/location-dashboard/location/desert-warpath.js
+++ b/src/modules/location-dashboard/location/desert-warpath.js
@@ -21,10 +21,10 @@ const getFieryWarpathText = (quests) => {
 
   let streakText = '';
   if (quest.streak !== 0) {
-    streakText = `, ${quest.streak} streak`;
+    streakText = `· ${quest.streak} streak`;
   }
 
-  return `Wave ${quest.wave}: ${quest.percent}% remaining${streakText} `;
+  return `Wave ${quest.wave}: ${100 - quest.percent}% remaining${streakText} `;
 };
 
 /**

--- a/src/modules/location-dashboard/location/floating-islands.js
+++ b/src/modules/location-dashboard/location/floating-islands.js
@@ -62,7 +62,11 @@ export default (quests) => {
 
   const powerType = powerTypes[quest.island_power_type];
 
-  let returnText = `<div class='dashboard-fi-tiles'>${tileText}</div> ${powerType} ${type}`;
+  let returnText = '<div class="dashboard-fi-wrap">';
+  returnText += `<div class='dashboard-fi-tiles'>${tileText}</div>`;
+  returnText += `<div class='dashboard-fi-type'>${powerType} ${type}</div>`;
+  returnText += '</div>';
+
   if (quest.isLai) {
     returnText += `<div class="stats">${quest.hunts_remaining} hunts remaining, ${quest.wardens_caught} wardens caught</div>`;
   } else {

--- a/src/modules/location-dashboard/location/moussu-picchu.js
+++ b/src/modules/location-dashboard/location/moussu-picchu.js
@@ -21,9 +21,9 @@ export default (quests) => {
     windLevel: quests?.QuestMoussuPicchu?.elements?.wind?.level || null,
   };
 
-  if ('none' !== quest.stormLevel) {
-    return `${uppercaseFirstLetter(quest.stormLevel)} Storm`;
+  if (quest.rainPercent === 100 && quest.windPercent === 100) {
+    return 'Max Storm · Wind (100%) · Rain (100%)';
   }
 
-  return `${uppercaseFirstLetter(quest.windLevel)} Wind (${quest.windPercent}%), ${uppercaseFirstLetter(quest.rainLevel)} Rain (${quest.rainPercent}%)`;
+  return `${uppercaseFirstLetter(quest.windLevel)} Wind (${quest.windPercent}%) · ${uppercaseFirstLetter(quest.rainLevel)} · Rain (${quest.rainPercent}%)`;
 };

--- a/src/modules/location-dashboard/styles.css
+++ b/src/modules/location-dashboard/styles.css
@@ -314,3 +314,9 @@ img.locationImage {
 .dashboard-bb-wrap.embellishments .tile.ruby_remover {
   background-image: url(https://www.mousehuntgame.com/images/items/stats/large/6753553ca41cb4754fba0ebf7600378b.png);
 }
+
+.locationImageWrapper:hover,
+.locationName:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/src/modules/location-dashboard/styles.css
+++ b/src/modules/location-dashboard/styles.css
@@ -269,35 +269,31 @@ img.locationImage {
   width: 20px;
   height: 20px;
   color: transparent;
-  background-image: url(https://www.mousehuntgame.com/images/ui/hud/floating_islands/mods.png);
-}
-
-.dashboard-bb-wrap .tile {
   background-image: url(https://www.mousehuntgame.com/images/ui/hud/bountiful_beanstalk/chevrons.png?asset_cache_version=3);
-  background-size: 100%
+  background-size: 100%;
 }
 
 .dashboard-bb-wrap .tile.standard {
-  background-position-y: 0%
+  background-position-y: 0%;
 }
 
 .dashboard-bb-wrap .tile.super {
-  background-position-y: 34%
+  background-position-y: 34%;
 }
 
 .dashboard-bb-wrap .tile.extreme {
-  background-position-y: 67%
+  background-position-y: 67%;
 }
 
 .dashboard-bb-wrap .tile.ultimate {
-  background-position-y: 100%
+  background-position-y: 100%;
 }
 
 .dashboard-bb-wrap.room-name {
   display: flex;
-  justify-content: flex-end;
-  align-items: center;
   gap: 5px;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .dashboard-bb-wrap.embellishments .tile {
@@ -308,13 +304,13 @@ img.locationImage {
 }
 
 .dashboard-bb-wrap.embellishments .tile.golden_key {
-  background-image: url(https://www.mousehuntgame.com/images/items/stats/large/d855937c33e0fc0db25fbdf1aea70aa2.png);'
+  background-image: url(https://www.mousehuntgame.com/images/items/stats/large/d855937c33e0fc0db25fbdf1aea70aa2.png);
 }
 
 .dashboard-bb-wrap.embellishments .tile.golden_feather {
-  background-image: url(https://www.mousehuntgame.com/images/items/stats/large/654d4e0c8308c3ab0ee99d32503bf82a.png);'
+  background-image: url(https://www.mousehuntgame.com/images/items/stats/large/654d4e0c8308c3ab0ee99d32503bf82a.png);
 }
 
 .dashboard-bb-wrap.embellishments .tile.ruby_remover {
-  background-image: url(https://www.mousehuntgame.com/images/items/stats/large/6753553ca41cb4754fba0ebf7600378b.png)
+  background-image: url(https://www.mousehuntgame.com/images/items/stats/large/6753553ca41cb4754fba0ebf7600378b.png);
 }

--- a/src/modules/location-dashboard/styles.css
+++ b/src/modules/location-dashboard/styles.css
@@ -255,3 +255,66 @@ img.locationImage {
 .dashboard-fi-tiles {
   vertical-align: middle;
 }
+
+.dashboard-fi-wrap {
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+  justify-content: flex-end;
+  margin-bottom: -5px;
+}
+
+.dashboard-bb-wrap .tile {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  color: transparent;
+  background-image: url(https://www.mousehuntgame.com/images/ui/hud/floating_islands/mods.png);
+}
+
+.dashboard-bb-wrap .tile {
+  background-image: url(https://www.mousehuntgame.com/images/ui/hud/bountiful_beanstalk/chevrons.png?asset_cache_version=3);
+  background-size: 100%
+}
+
+.dashboard-bb-wrap .tile.standard {
+  background-position-y: 0%
+}
+
+.dashboard-bb-wrap .tile.super {
+  background-position-y: 34%
+}
+
+.dashboard-bb-wrap .tile.extreme {
+  background-position-y: 67%
+}
+
+.dashboard-bb-wrap .tile.ultimate {
+  background-position-y: 100%
+}
+
+.dashboard-bb-wrap.room-name {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 5px;
+}
+
+.dashboard-bb-wrap.embellishments .tile {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  color: transparent;
+}
+
+.dashboard-bb-wrap.embellishments .tile.golden_key {
+  background-image: url(https://www.mousehuntgame.com/images/items/stats/large/d855937c33e0fc0db25fbdf1aea70aa2.png);'
+}
+
+.dashboard-bb-wrap.embellishments .tile.golden_feather {
+  background-image: url(https://www.mousehuntgame.com/images/items/stats/large/654d4e0c8308c3ab0ee99d32503bf82a.png);'
+}
+
+.dashboard-bb-wrap.embellishments .tile.ruby_remover {
+  background-image: url(https://www.mousehuntgame.com/images/items/stats/large/6753553ca41cb4754fba0ebf7600378b.png)
+}

--- a/src/modules/location-huds/bountiful-beanstalk/index.js
+++ b/src/modules/location-huds/bountiful-beanstalk/index.js
@@ -243,7 +243,7 @@ const addCraftingButtons = async () => {
 
       const baitQuantityType = baitQuantity.getAttribute('data-item-type');
       if (baitQuantityType && newQuantities[baitQuantityType]) {
-        baitQuantity.innerText = newQuantities[baitQuantityType];
+        baitQuantity.innerText = newQuantities[baitQuantityType].toLocaleString();
       }
 
       const baitCraftQty = bait.querySelector('.headsUpDisplayBountifulBeanstalkView__ingredientQuantity');
@@ -253,7 +253,7 @@ const addCraftingButtons = async () => {
 
       const baitIngredientType = baitCraftQty.getAttribute('data-item-type');
       if (baitIngredientType && newQuantities[baitIngredientType]) {
-        baitCraftQty.innerText = newQuantities[baitIngredientType];
+        baitCraftQty.innerText = newQuantities[baitIngredientType].toLocaleString();
       }
     });
 

--- a/src/modules/location-huds/bountiful-beanstalk/index.js
+++ b/src/modules/location-huds/bountiful-beanstalk/index.js
@@ -142,33 +142,6 @@ const toggleFuelWithIcon = async () => {
   });
 };
 
-const updateTitle = async () => {
-  const title = document.querySelector('.bountifulBeanstalkCastleView__title');
-  if (! title) {
-    return;
-  }
-
-  if (title.classList.contains('loot-displayed')) {
-    const display = document.querySelector('.loot-display');
-    if (display) {
-      display.remove();
-    }
-  }
-
-  const loot = document.querySelector('.bountifulBeanstalkCastleView__currentRoomLoot');
-  const lootMult = document.querySelector('.bountifulBeanstalkCastleView__currentRoomLootMultiplier');
-
-  if (! loot || ! lootMult) {
-    title.classList.remove('loot-displayed');
-    return;
-  }
-
-  if (loot.innerText && lootMult.innerText) {
-    makeElement('div', 'loot-display', `${lootMult.innerText}x ${loot.innerText}`, title);
-    title.classList.add('loot-displayed');
-  }
-};
-
 const updateLootText = async () => {
   const ccLoot = document.querySelector('.headsUpDisplayBountifulBeanstalkView__multiplier.headsUpDisplayBountifulBeanstalkView__multiplier--condensed_creativity div');
   if (ccLoot) {
@@ -340,7 +313,6 @@ export default async () => {
   keepTooltipToggled();
   makeGiantMoreVisible();
   toggleFuelWithIcon();
-  updateTitle();
   updateLootText();
   addCraftingButtons();
 

--- a/src/modules/location-huds/bountiful-beanstalk/styles.css
+++ b/src/modules/location-huds/bountiful-beanstalk/styles.css
@@ -211,6 +211,8 @@
 }
 
 .headsUpDisplayBountifulBeanstalkView__baitCraftableContainer .mousehuntTooltip {
+  right: -40px;
+  left: -40px;
   line-height: 1.5;
   text-align: center;
 }

--- a/src/modules/location-huds/bountiful-beanstalk/styles.css
+++ b/src/modules/location-huds/bountiful-beanstalk/styles.css
@@ -328,24 +328,6 @@
   left: -2px;
 }
 
-.loot-displayed.bountifulBeanstalkCastleView__title > div {
-  position: absolute;
-  top: 18px;
-  right: 50px;
-  left: 50px;
-  height: 18px;
-  font-size: 11px;
-  font-weight: 400;
-  line-height: 16px;
-  background: linear-gradient(90deg, #f4e4a6 0%, #faedb1 50%, #f4e4a6 100%);
-  border-radius: 42%;
-  box-shadow: 0 3px 3px -2px #6d3421;
-}
-
-.loot-displayed.bountifulBeanstalkCastleView__title {
-  bottom: 243px;
-}
-
 .headsUpDisplayBountifulBeanstalkView__multiplier.headsUpDisplayBountifulBeanstalkView__multiplier--feather,
 .headsUpDisplayBountifulBeanstalkView__multiplier.headsUpDisplayBountifulBeanstalkView__multiplier--condensed_creativity {
   font-size: 10px;
@@ -421,4 +403,8 @@ button.headsUpDisplayBountifulBeanstalkView__baitBuyButton {
 .loading .mh-crafting-actions,
 .success .mh-crafting-actions {
   opacity: 0.1;
+}
+
+.folkloreForestRegionView-trapWarningContainer.active {
+  z-index: 35;
 }

--- a/src/modules/location-huds/desert-warpath/styles.css
+++ b/src/modules/location-huds/desert-warpath/styles.css
@@ -122,12 +122,16 @@
 .warpathHud-missle-activate {
   position: absolute;
   top: -15px;
-  left: -26px;
+  left: -150px;
   cursor: pointer;
   opacity: 0.4;
   transition: 0.3s;
   transform: rotate(270deg) scale(0.8);
   animation: none;
+}
+
+.wave_4 .warpathHud-missle-activate {
+  left: -26px;
 }
 
 .warpathHud-missle-activate:hover {
@@ -138,4 +142,9 @@
 .warpathHUD-engaged .warpathHud-missle-activate {
   filter: hue-rotate(281deg);
   opacity: 0.9;
+}
+
+.warpathHUD-streakContainer.streak_0 .warpathHUD-streak-image-empty {
+  color: transparent;
+  text-shadow: none;
 }

--- a/src/modules/location-huds/event-locations/spring-egg-hunt/index.js
+++ b/src/modules/location-huds/event-locations/spring-egg-hunt/index.js
@@ -3,6 +3,7 @@ import {
   makeElement,
   onDialogShow,
   onEvent,
+  onRequest,
   setMultipleTimeout
 } from '@utils';
 
@@ -46,6 +47,39 @@ const addUnfoundEggHighlightWithTimeout = () => {
   }, [10, 500, 1000]);
 };
 
+const rightclickToFlag = () => {
+  const board = document.querySelector('.eggSweeper');
+  if (! board) {
+    return;
+  }
+
+  const isFlagMode = board.classList.contains('flags');
+  if (isFlagMode) {
+    return;
+  }
+
+  const spaces = board.querySelectorAll('.eggSweeper-board-row-cell');
+  if (! spaces) {
+    return;
+  }
+
+  // Add an event listener to each space and if it is right-clicked, toggle the class on the parent.
+  spaces.forEach((space) => {
+    space.addEventListener('contextmenu', async (e) => {
+      const cell = space.querySelector('a');
+      if (! cell) {
+        return;
+      }
+
+      e.preventDefault();
+
+      hg.views.EggstremeEggscavationView.setFlagMode();
+      hg.views.EggstremeEggscavationView.pickTile(cell);
+      hg.views.EggstremeEggscavationView.setShovelMode();
+    });
+  });
+};
+
 /**
  * Always active.
  */
@@ -55,6 +89,16 @@ const springEggHuntGlobal = async () => {
   onDialogShow('springHuntPopup', () => {
     addUnfoundEggHighlightWithTimeout();
     onEvent('ajax_response', addUnfoundEggHighlightWithTimeout, true);
+  });
+
+  onDialogShow('eggSweeperPopup', () => {
+    setTimeout(rightclickToFlag, 1000);
+  });
+
+  onRequest('events/eggstreme_eggscavation.php', (request, data) => {
+    if ('show_field' === data.action) {
+      setTimeout(rightclickToFlag, 1000);
+    }
   });
 
   setMultipleTimeout(() => {

--- a/src/modules/location-huds/event-locations/spring-egg-hunt/styles.css
+++ b/src/modules/location-huds/event-locations/spring-egg-hunt/styles.css
@@ -6,7 +6,7 @@
   left: -9px;
   outline: 1px solid #364661;
   box-shadow:
-    0 0 125px #1be300 inset,
+    0 0 125px #bbffb3 inset,
     0 1px 6px -2px #000;
 }
 
@@ -178,4 +178,13 @@
 
 .springHuntHUD-setMaxQuantityButton {
   font-size: 14px;
+}
+
+.springHuntHUD-popup-dialogContainer {
+  top: 50vh;
+}
+
+.springHuntHUD-popup-dialogFrame-content {
+  max-height: 60vh;
+  overflow-y: auto;
 }

--- a/src/modules/location-huds/event-locations/spring-egg-hunt/styles.css
+++ b/src/modules/location-huds/event-locations/spring-egg-hunt/styles.css
@@ -52,6 +52,7 @@
 .springHuntHUD-shop-cost {
   margin-top: -2px;
   font-size: 12px;
+  border-color: #999;
 }
 
 .springHuntHUD-shelf .springHuntHUD-shelf-itemsContainer {
@@ -187,4 +188,9 @@
 .springHuntHUD-popup-dialogFrame-content {
   max-height: 60vh;
   overflow-y: auto;
+}
+
+.springHuntHUD-shelf-item .itemImage {
+  border-width: 1px;
+  box-shadow: inset 0 0 7px -1px #db882f;
 }

--- a/src/modules/location-huds/floating-islands/index.js
+++ b/src/modules/location-huds/floating-islands/index.js
@@ -258,19 +258,20 @@ const updateJetstreamTime = async () => {
     return;
   }
 
-  container.innerHTML = '';
-
   if (! user?.quests?.QuestFloatingIslands?.jet_stream_active) {
+    container.innerHTML = '';
     return;
   }
 
   const expiry = document.querySelector('.floatingIslandsHUD-jetstream .trapImageView-tooltip-trapAura-expiry span');
   if (! expiry) {
+    container.innerHTML = '';
     return;
   }
 
   const dateParts = expiry.innerText.split(' ');
   if (! dateParts.length || dateParts.length < 5) {
+    container.innerHTML = '';
     return;
   }
 
@@ -301,6 +302,10 @@ const updateJetstreamTime = async () => {
     spacer: '',
     delimiter: ' ',
   });
+
+  if (container.innerText === duration) {
+    return;
+  }
 
   container.innerText = duration;
 };
@@ -426,9 +431,16 @@ const hud = () => {
   onEvent('horn-countdown-tick', updateJetstreamTime);
   onDialogShow('floatingIslandsAdventureBoard.floatingIslandsDialog.skyPalace', onSkyMapShow);
 
-  onRequest('environment/floating_islands.php', () => {
+  onRequest('environment/floating_islands.php', (request, data) => {
     run();
     toggleFuel(true);
+
+    if (data?.action === 'launch') {
+      setTimeout(() => {
+        run();
+        showBWReminder();
+      }, 2000);
+    }
   });
 };
 

--- a/src/modules/location-huds/floating-islands/styles.css
+++ b/src/modules/location-huds/floating-islands/styles.css
@@ -116,6 +116,11 @@ span.floatingIslandsHUD-huntsRemaining {
 }
 
 .floatingIslandsWorkshop-part-name {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 70%;
+  height: 15px;
   font-size: 11px;
   text-shadow: none;
 }
@@ -183,20 +188,21 @@ span.floatingIslandsHUD-huntsRemaining {
 /* Fancy countdown */
 .mh-ui-fi-enemy-countdown {
   position: absolute;
-  top: 3px;
-  bottom: -4px;
+  top: 0;
+  bottom: -3px;
   left: -1px;
   z-index: 4;
   width: auto;
   min-width: 70px;
-  padding-left: 5px;
+  padding-right: 2px;
+  padding-left: 4px;
+  line-height: 29px;
   white-space: nowrap;
   background-color: #51250a;
-  border-radius: 8px;
-  border-bottom-left-radius: 0;
+  border-radius: 6px 5px 5px 0;
   box-shadow:
-    1px 0 0 1px #7d5430,
-    inset 1px 0 0 1px #9a6f43;
+    1px 0 0 1px #b2630e,
+    inset 1px 0 0 1px #7d5430;
 }
 
 span.mh-ui-fi-enemy-countdown-hunts {
@@ -318,22 +324,12 @@ a.floatingIslandsHUD-islandLoot:focus {
   transform: scale(1.1) rotate(2deg);
 }
 
-.floatingIslandsHUD-enemyContainer .floatingIslandsHUD-enemy-thumb {
-  transition: 0.3s ease-in;
-  transform: scale(1.1) translate(-2px, -3px);
-  transform-origin: left;
-}
-
 .floatingIslandsHUD-enemyContainer:hover .floatingIslandsHUD-enemy-thumb {
-  transform: scale(1.3) rotate(5deg) translate(-10px, -7px);
+  box-shadow: inset 1px -1px 5px 7px #fb7660;
 }
 
 .floatingIslandsHUD-enemy-thumbContainer {
   overflow: hidden;
-}
-
-.floatingIslandsAdventureBoardSkyMap-rerollButton.busy {
-  pointer-events: none;
 }
 
 .floatingIslandsAdventureBoard-info span {
@@ -373,7 +369,7 @@ a.floatingIslandsHUD-islandLoot:focus {
   right: 0;
   width: auto;
   min-width: 100px;
-  font-size: 11px;
+  font-size: 13px;
   color: #71d0ff;
   text-align: right;
 }
@@ -395,6 +391,16 @@ a.floatingIslandsHUD-islandLoot:focus {
   top: 35px;
   padding: 2px;
   font-size: 12px;
+  box-shadow:
+    0 0 100px rgb(255 255 255 / 80%) inset,
+    0 0 2px #333;
+}
+
+.floatingIslandsHUD-statItem-quantity {
+  z-index: 1;
+  box-shadow:
+    0 0 100px rgb(255 255 255 / 81%) inset,
+    0 0 2px #333;
 }
 
 .inventoryBag .floatingIslandsHUD-inventoryBag-item-name {
@@ -406,8 +412,49 @@ a.floatingIslandsHUD-islandLoot:focus {
   animation: dirigibleFloat 5s infinite;
 }
 
+.floatingIslandsWorkshop-dirigiblePreview .floatingIslandsAirship::before {
+  position: absolute;
+  top: 45px;
+  right: -10px;
+  left: -30px;
+  display: block;
+  height: 170px;
+  overflow: hidden;
+  content: "";
+  background: url(https://i.mouse.rip/airship-shadow.png) no-repeat;
+  background-position: bottom center;
+  background-size: 190px;
+  opacity: 0.2;
+  transform: perspective(600px) rotateX(67deg);
+}
+
+.floatingIslandsWorkshop-dirigiblePreview .floatingIslandsAirship.animate::before {
+  animation: mh-improved-dirigible-float-shadow 2s infinite;
+}
+
+@keyframes mh-improved-dirigible-float-shadow {
+  0% {
+    top: 45px;
+    background-size: 180px;
+  }
+
+  50% {
+    top: 40px;
+    background-size: 190px;
+  }
+
+  100% {
+    top: 45px;
+    background-size: 180px;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .floatingIslandPaperDoll-mod {
+    animation: none;
+  }
+
+  .floatingIslandsWorkshop-dirigiblePreview .floatingIslandsAirship::before {
     animation: none;
   }
 }
@@ -415,4 +462,165 @@ a.floatingIslandsHUD-islandLoot:focus {
 .floatingIslandsHUD-warningContainer {
   top: 20px;
   left: 548px;
+}
+
+.floatingIslandsHUD-statItemContainer {
+  left: 250px;
+  justify-content: space-evenly;
+  width: 335px;
+}
+
+.floatingIslandsHUD-statItem.active {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.floatingIslandsHUD-bait-image {
+  inset: 1px;
+  background-repeat: no-repeat;
+  background-size: 32px;
+  box-shadow:
+    1px 1px 1px #b75d06 inset,
+    1px 1px 1px #b75d06 inset;
+}
+
+a.floatingIslandsHUD-bait-image:hover {
+  background-size: 32px;
+  box-shadow: 0 0 2px 2px #10ff00 inset;
+}
+
+.floatingIslandsHUD-bait-craftingItem-image {
+  background-repeat: no-repeat;
+  background-position: 1px 2px;
+  background-size: 23px;
+  box-shadow:
+    1px 1px 1px #b75d06 inset,
+    1px 1px 1px #b75d06 inset,
+    1px -1px 1px 0 #b75d06 inset;
+}
+
+.sky_pirate_cheese .floatingIslandsHUD-bait-craftingItem-image {
+  background-position: 1px 0;
+  background-size: 22px;
+  box-shadow:
+    1px 1px 1px #b75d06 inset,
+    1px 1px 1px #b75d06 inset;
+}
+
+.floatingIslandsHUD-bait.sky_cheese.extra_rich_sky_cheese .floatingIslandsHUD-bait-craftingItem-image {
+  top: 24px;
+}
+
+.floatingIslandsHUD-bait.sky_cheese.extra_rich_sky_cheese .floatingIslandsHUD-bait-image.extra_rich_sky_cheese {
+  background-position: 3px 4px;
+  background-size: 29px;
+}
+
+.floatingIslandsWorkshop-dirigiblePreview .floatingIslandsAirship-part {
+  top: -10px;
+  background-repeat: no-repeat;
+}
+
+.floatingIslandsWorkshop-part.active .floatingIslandsWorkshop-part-border,
+.floatingIslandsWorkshop-part:hover .floatingIslandsWorkshop-part-border {
+  background-color: #fcfcef;
+  border: 1px solid #edd28a;
+}
+
+.floatingIslandsWorkshop-part.active {
+  order: -1;
+}
+
+.floatingIslandsWorkshop-part.active .floatingIslandsWorkshop-part-border::after {
+  border-width: 2px;
+}
+
+.floatingIslandsWorkshop-part-state.active .mousehuntActionButton.selected,
+.floatingIslandsWorkshop-part-state.active .mousehuntActionButton.selected::before {
+  background: none;
+  border: none;
+  box-shadow: none;
+}
+
+.floatingIslandsWorkshop-part-state.active .mousehuntActionButton span {
+  font-style: normal;
+}
+
+.floatingIslandsWorkshop-part .floatingIslandsWorkshop-part-border {
+  border: 1px solid #edd28a;
+  box-shadow: inset 0 -1px 5px 2px #edd28a;
+}
+
+.floatingIslandsWorkshop-part-state .mousehuntActionButton.lightBlue {
+  box-shadow: none;
+}
+
+.floatingIslandsWorkshop-part {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.floatingIslandsHUD .floatingIslandsHUD-enemyContainer.hasEnemy:hover .floatingIslandsHUD-enemy-thumb {
+  transform: scale(1.3);
+}
+
+.floatingIslandsHUD .floatingIslandsHUD-enemyContainer.hasEnemy:active .floatingIslandsHUD-enemy-thumb {
+  transform: scale(1.3) rotate(360deg);
+}
+
+.floatingIslandsHUD .floatingIslandsHUD-enemyContainer.hasEnemy .floatingIslandsHUD-enemy-thumb {
+  transition: 0.4s ease-in;
+}
+
+.floatingIslandsHUD-modPanelTooltip-islandEffects.active .floatingIslandsHUD-modPanelTooltip-effectContainer.specialEffect::after,
+.floatingIslandsHUD-modPanelTooltip-islandEffects.active .floatingIslandsHUD-modPanelTooltip-effectContainer.reward::after,
+.floatingIslandsHUD-modPanelTooltip-islandEffects.complete .floatingIslandsHUD-modPanelTooltip-effectContainer.specialEffect::after,
+.floatingIslandsHUD-modPanelTooltip-islandEffects.complete .floatingIslandsHUD-modPanelTooltip-effectContainer.reward::after,
+.floatingIslandsHUD-modPanelTooltip-islandEffects.complete .floatingIslandsHUD-modPanelTooltip-effectContainer.oneTimeReward::after {
+  bottom: 3px;
+}
+
+.floatingIslandsHUD-modPanelTooltip-effect {
+  font-size: 12px;
+  text-align: center;
+}
+
+.floatingIslandsHUD-item-image.cloud_curd_crafting_item {
+  background-position: 50% 10%;
+  background-size: 30px;
+}
+
+.floatingIslandsHUD-modPanelTooltip .floatingIslandsHUD-item-image.cloud_curd_crafting_item {
+  background-position: 50% 2px;
+}
+
+.floatingIslandsHUD-bait.sky_cheese.extra_rich_sky_cheese .floatingIslandsHUD-bait-quantity.sky_cheese {
+  top: 8px;
+}
+
+.floatingIslandsHUD-navigationButtons.showSkyPalace .floatingIslandsHUD-skyPalaceFuel .quantity {
+  font-size: 13px;
+}
+
+.floatingIslandsAdventureBoardSkyMap-rerollButton {
+  animation: mh-improved-fade-busy 3s 1;
+}
+
+.floatingIslandsAdventureBoardSkyMap-rerollButton.busy {
+  pointer-events: none;
+  animation: none;
+}
+
+.floatingIslandsHUD-modPanel.highlight::after {
+  border: 1px solid #f5d98d;
+  box-shadow: 0 0 3px 3px #ffdcbe inset;
+}
+
+.floatingIslandsHUD-modPanelTooltip-effect-label {
+  color: #f4d78c;
+  text-align: center;
+  text-shadow: 1px 1px 1px #754426;
 }

--- a/src/modules/location-huds/floating-islands/styles.css
+++ b/src/modules/location-huds/floating-islands/styles.css
@@ -345,6 +345,11 @@ a.floatingIslandsHUD-islandLoot:focus {
   height: 30px;
 }
 
+.launch_pad_island .floatingIslandsHUD-jetstream {
+  top: 12px;
+  right: 47px;
+}
+
 .floatingIslandsHUD-jetstream .trapImageView-trapAura.active {
   width: 30px;
   height: 30px;

--- a/src/modules/quick-send-supplies/settings/index.js
+++ b/src/modules/quick-send-supplies/settings/index.js
@@ -8,10 +8,7 @@ import { getTradableItems } from '@utils';
 export default async () => {
   const tradableItems = await getTradableItems('type');
 
-  tradableItems.unshift({
-    name: 'None',
-    value: '',
-  });
+  tradableItems.unshift({ name: 'None', value: 'none' }, { seperator: true });
 
   return [{
     id: 'quick-send-supplies.items',

--- a/src/modules/quick-send-supplies/styles.css
+++ b/src/modules/quick-send-supplies/styles.css
@@ -20,6 +20,10 @@
   transform: translate(-50%);
 }
 
+.treasureMapView-hunter-wrapper .quickSendWrapper {
+  top: 60px !important;
+}
+
 .userInteractionButtonsView-buttonGroup:hover .quickSendWrapper,
 .quickSendWrapper:hover {
   display: block;

--- a/src/modules/required/index.js
+++ b/src/modules/required/index.js
@@ -4,6 +4,7 @@ import {
   getCurrentPage,
   getFlag,
   getHeaders,
+  makeElement,
   onDialogShow,
   onEvent,
   onRequest,
@@ -132,6 +133,24 @@ const addDialogListeners = () => {
 const checkForMHCT = () => {
   const hasMhct = document.querySelector('#mhhh_version');
   console.log(hasMhct ? 'MHCT is installed' : 'MHCT is not installed'); // eslint-disable-line no-console
+  // todo: add a popup to inform the user that they should install MHCT.
+};
+
+const addSupportLink = () => {
+  const description = document.querySelector('#overlayPopup .jsDialogContainer .contactUsForm .description');
+  if (! description) {
+    return;
+  }
+
+  const supportWrap = makeElement('div', 'support-link');
+
+  makeElement('p', '', 'Before contacting support, please make sure that the issue isn\'t caused by MouseHunt Improved. If it is, please report it on the GitHub page.', supportWrap);
+  const supportLink = makeElement('a', '', 'Visit the MouseHunt Improved GitHub page');
+  supportLink.href = 'https://github.com/MHCommunity/mousehunt-improved/issues';
+  supportLink.target = '_blank';
+  supportWrap.append(supportLink);
+
+  description.before(supportWrap);
 };
 
 /**
@@ -149,6 +168,8 @@ const init = async () => {
   addJournalProcessingEvents();
 
   checkForMHCT();
+
+  onEvent('dialog-show-support', addSupportLink);
 };
 
 export default {

--- a/src/modules/required/index.js
+++ b/src/modules/required/index.js
@@ -4,7 +4,6 @@ import {
   getCurrentPage,
   getFlag,
   getHeaders,
-  onDialogHide,
   onDialogShow,
   onEvent,
   onRequest,

--- a/src/modules/required/index.js
+++ b/src/modules/required/index.js
@@ -100,7 +100,8 @@ const processSingleEntries = async () => {
 };
 
 const addJournalProcessingEvents = async () => {
-  processEntries();
+  setMultipleTimeout(processEntries, [100, 500, 1000]);
+
   onRequest('*', (data) => {
     setMultipleTimeout(processEntries, [100, 500, 1000]);
 

--- a/src/modules/show-auras/grid.css
+++ b/src/modules/show-auras/grid.css
@@ -7,9 +7,8 @@
   flex-flow: row nowrap;
   justify-content: space-evenly;
   max-width: 325px;
-  padding: 5px 0;
+  padding: 10px 0 0;
   margin: 5px 0;
-  overflow: hidden;
   cursor: default;
 }
 

--- a/src/modules/show-auras/index.js
+++ b/src/modules/show-auras/index.js
@@ -107,7 +107,8 @@ const addTrapBlock = () => {
     const tooltip = makeElement('div', ['mousehuntTooltip', 'top', 'noEvents']);
     const tooltipContent = makeElement('div', 'mousehuntTooltipContent');
     makeElement('div', 'mousehuntTooltipContentTitle', `${aura.type} Aura`, tooltipContent);
-    makeElement('div', 'mousehuntTooltipContentTime', `Expires on ${expiryText}, ${remaining} remaining`, tooltipContent);
+    makeElement('div', 'mousehuntTooltipContentTime', `Expires on ${expiryText}`, tooltipContent);
+    makeElement('div', 'mousehuntTooltipContentTime', `${remaining} remaining`, tooltipContent);
     tooltip.append(tooltipContent);
 
     makeElement('div', 'mousehuntTooltip-arrow', '', tooltip);

--- a/src/modules/show-auras/styles.css
+++ b/src/modules/show-auras/styles.css
@@ -1,6 +1,6 @@
 .mh-improved-aura-view .aura .mousehuntTooltip {
   right: -50px;
-  bottom: 60px;
+  bottom: 70px;
   left: -50px;
   padding: 5px;
   font-weight: 400;

--- a/src/modules/taller-windows/styles.css
+++ b/src/modules/taller-windows/styles.css
@@ -3,7 +3,6 @@
 .convertibleOpenView-itemContainer,
 .marketplaceView-browse-content,
 .MHCheckoutAllRewardsPageView,
-.treasureMapRootView-content,
 .treasureMapListingsView-tableView,
 .treasureMapView-block-content.tall,
 .treasureMapView-blockWrapper.tall .treasureMapView-block-content,
@@ -33,14 +32,6 @@
 .treasureMapDialogView.limitHeight .treasureMapView-block-content,
 .treasureMapDialogView.limitHeight .treasureMapDialogView-content {
   max-height: 75vh;
-}
-
-.treasureMapDialogView.wide.limitHeight {
-  transform: translate(-50%, -100px);
-}
-
-.treasureMapDialogView.wide.limitHeight.confirm {
-  transform: translate(-50%, -165px);
 }
 
 .giftSelectorView-inbox-giftContainer,

--- a/src/modules/taller-windows/styles.css
+++ b/src/modules/taller-windows/styles.css
@@ -3,6 +3,7 @@
 .convertibleOpenView-itemContainer,
 .marketplaceView-browse-content,
 .MHCheckoutAllRewardsPageView,
+.treasureMapRootView-content,
 .treasureMapListingsView-tableView,
 .treasureMapView-block-content.tall,
 .treasureMapView-blockWrapper.tall .treasureMapView-block-content,
@@ -39,7 +40,7 @@
 }
 
 .treasureMapDialogView.wide.limitHeight.confirm {
-  transform: translate(-50%, -125px);
+  transform: translate(-50%, -165px);
 }
 
 .giftSelectorView-inbox-giftContainer,
@@ -64,90 +65,51 @@
   max-height: 500px;
 }
 
-/* FI airship */
-.floatingIslandsWorkshop-parts-content {
+.floatingIslandsWorkshop-partsContainer {
+  top: 263px;
+  left: 113px;
+  width: 533px;
   height: auto;
-  background: linear-gradient(255deg, #fbf3b0 75%, #fdfcc7 100%);
-  border-bottom-right-radius: 10px;
-  border-bottom-left-radius: 10px;
-  outline: 10px solid #fbf3ae;
-  box-shadow:
-    0 2px 1px 11px #b9570e,
-    0 3px 2px 12px #985316,
-    0 4px 1px 13px #84420f,
-    0 5px 1px 14px #c47728,
-    0 6px 1px 15px #cd7f2c,
-    0 7px 1px 16px #e19439;
+  background-image: url(https://i.mouse.rip/fi-airships-middle.png);
+  background-size: contain;
+  border-radius: 12px;
+}
+
+.floatingIslandsWorkshop-parts-content {
+  position: relative;
+  height: 100%;
+  max-height: 60vh;
+}
+
+.floatingIslandsWorkshop-parts-title {
+  padding: 5px 10px 0;
+  margin-top: -23px;
+  margin-right: -1px;
+  background: radial-gradient(circle, #fdf9bd 0%, #fefdd6 50%, #fdf9bd 100%);
+  border: none;
+  border-radius: 4px 5px 0 0;
+}
+
+.floatingIslandsWorkshop-partsContainer::after {
+  position: absolute;
+  bottom: -3px;
+  left: 0;
+  width: 533px;
+  height: 30px;
+  content: "";
+  background-image: url(https://i.mouse.rip/fi-airships-bottom-2.png);
+  background-position: bottom;
 }
 
 .floatingIslandsWorkshop-stabilizer {
-  top: 325px;
-  right: 78px;
-  left: unset;
-  border: none;
-  transform: rotate(90deg);
-}
-
-.floatingIslandsWorkshop-stabilizer label {
-  color: #848383;
-}
-
-.floatingIslandsWorkshop-part-name {
   position: absolute;
-  top: 0;
-  right: 10px;
-  left: 0;
-}
-
-.floatingIslandsWorkshop-part-border {
-  margin-top: 18px;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-
-.floatingIslandsWorkshop-part-state a.mousehuntActionButton.tiny.lightBlue {
-  font-size: 9px;
-  background: #fefad7;
-  box-shadow: none;
-}
-
-.floatingIslandsWorkshop-part-state a.mousehuntActionButton.tiny.lightBlue::before {
-  background: #fff9c3;
-  box-shadow: 0 0 10px #f3ecb2 inset;
-}
-
-.floatingIslandsWorkshop-parts-total {
-  margin-right: 15px;
-}
-
-.floatingIslandsWorkshop-partsContainer {
-  background-color: #fbf3ae;
-  border-radius: 5px;
-}
-
-.floatingIslandsWorkshop-part.active .floatingIslandsWorkshop-part-border {
-  background-color: #90cefa;
-}
-
-.floatingIslandsWorkshop-part-state .mousehuntActionButton.tiny.selected {
-  box-shadow: none;
-}
-
-.floatingIslandsWorkshop-part-actions {
-  background-color: #c48648;
-}
-
-.floatingIslandsWorkshop-part.active .floatingIslandsWorkshop-part-border::after {
-  border: none;
+  top: 250px;
+  left: 430px;
 }
 
 /* select 2 */
 .select2-results {
   max-height: 50vh;
-}
-
-.treasureMapDialogView.limitHeight .treasureMapDialogView-content {
-  max-height: unset;
 }
 
 .giftSelectorView-scroller {

--- a/src/modules/tip-of-the-day/index.js
+++ b/src/modules/tip-of-the-day/index.js
@@ -1,0 +1,53 @@
+import { addJournalEntry, addStyles, getSetting, saveSetting } from '@utils';
+
+import styles from './styles.css';
+
+const tips = [
+  'Did you know that MouseHunt Improved has many easter eggs? Try to find them all!',
+  'You can customize the modules you want to load in the settings.',
+  'You can use the \'debug-all\' setting to enable all debug options.',
+  'You can use the \'debug-dialog\', \'debug-navigation\', \'debug-request\', \'debug-events\' settings to enable specific debug options.',
+  'You can use the \'debug\' function in the console to log messages.',
+  'You can use the \'app.mhutils\' object in the console to access all the utility functions.',
+  'You can use the \'app.mhui\' object in the console to access all the UI functions.',
+  'There are many features in MouseHunt Improved that aren\'t even documented!',
+];
+
+const addTipDaily = async () => {
+  const lastChangeValue = getSetting('tip-of-the-day.last', 0);
+  const lastChange = new Date(Number.parseInt(lastChangeValue, 10));
+  const now = new Date();
+
+  // Check if the current time is past midnight and the journal has not been changed today
+  if (
+    ! lastChange ||
+    lastChange.getDate() !== now.getDate() ||
+    lastChange.getMonth() !== now.getMonth() ||
+    lastChange.getFullYear() !== now.getFullYear()
+  ) {
+    addJournalEntry({
+      id: 'tip-of-the-day',
+      text: tips[Math.floor(Math.random() * tips.length)],
+      noDate: true,
+    });
+
+    saveSetting('tip-of-the-day.last', now.getTime());
+  }
+};
+
+/**
+ * Initialize the module.
+ */
+const init = async () => {
+  addStyles(styles, 'tip-of-the-day');
+
+  addTipDaily();
+};
+
+export default {
+  id: 'tip-of-the-day',
+  name: 'Tip of the Day',
+  type: 'beta',
+  default: false,
+  load: init,
+};

--- a/src/modules/tip-of-the-day/styles.css
+++ b/src/modules/tip-of-the-day/styles.css
@@ -1,0 +1,1 @@
+/* Tip of the day styles */

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -138,10 +138,6 @@ const getData = async (key) => {
  * Clear all the caches.
  */
 const clearCaches = async () => {
-  validDataFiles.forEach((file) => {
-    dbDelete('data', file);
-  });
-
   dbDeleteAll('ar-cache');
 
   for (const key of Object.keys(localStorage)) {

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -7,7 +7,7 @@
  */
 const database = async (databaseName) => {
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open(`mh-improved-${databaseName}`, 6);
+    const request = indexedDB.open(`mh-improved-${databaseName}`, 7);
 
     request.onerror = (event) => {
       reject(event.target.error);

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -341,9 +341,8 @@ let lastDialog = null;
  *
  * @param {Function} callback The callback to run.
  * @param {string}   overlay  The overlay to check for.
- * @param {boolean}  once     Whether or not to remove the event listener after it's fired.
  */
-const onDialogHide = (callback, overlay = null, once = false) => {
+const onDialogHide = (callback, overlay = null) => {
   const dialogMapping = getDialogMapping();
   if (overlay in dialogMapping && ! dialogHideCallbacks.some((item) => item.callback === callback)) {
     dialogHideCallbacks.push({

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,6 +9,7 @@ export * from './event-registry';
 export * from './flags';
 export * from './global';
 export * from './horn';
+export * from './journal';
 export * from './links';
 export * from './location';
 export * from './maps';

--- a/src/utils/journal.js
+++ b/src/utils/journal.js
@@ -1,0 +1,106 @@
+import { dbGet, dbSet } from './db';
+import { getCurrentLocationName } from './location';
+import { onEvent } from './event-registry';
+
+const replaceJournalEntry = (entry, opts = {}) => {
+  const {
+    classes = ['short'],
+    image = false,
+    text = 'Hello, world!',
+    time = false,
+    location = false,
+    callback = () => {},
+  } = opts;
+
+  let date = false;
+
+  if (time && location) {
+    date = `${time} - ${location}`;
+  } else if (time) {
+    date = time;
+  } else if (location) {
+    date = location;
+  }
+
+  entry.outerHTML = `<div class="entry ${classes.join(' ')}" data-entry-id="journal-entry-${opts.id}">
+    ${image ? `<div class="journalimage"><img src="${image}" border="0"></div>` : ''}
+    <div class="journalbody">
+      ${date ? `<div class="journaldate">${date}</div>` : ''}
+      <div class="journaltext">${text}</div>
+    </div>
+  </div>`;
+
+  callback(entry);
+};
+
+const makeJournalEntry = (opts = {}) => {
+  const existingEntry = document.querySelector(`.journalEntries .entry[data-entry-id="journal-entry-${opts.id}"]`);
+  if (existingEntry) {
+    return;
+  }
+
+  const entry = document.querySelector(`.journalEntries .entry${opts.before ? `[data-entry-id="${opts.before}"]` : ''}`);
+  if (! entry) {
+    return;
+  }
+
+  const newEntry = entry.cloneNode(true);
+  entry.before(newEntry);
+  replaceJournalEntry(newEntry, opts);
+};
+
+const getLatestJournalEntryId = () => {
+  const entries = document.querySelectorAll('.journalEntries .entry');
+
+  const entry = [...entries].find((search) => search.getAttribute('data-entry-id'));
+  return entry ? entry.getAttribute('data-entry-id') : 0;
+};
+
+const addJournalEntry = async (opts = {}) => {
+  const previousEntryData = await dbGet('data', `journal-entry-${opts.id}`);
+  const previousEntryId = previousEntryData ? previousEntryData.data?.previous : null;
+
+  if (! previousEntryId) {
+    const data = {
+      id: `journal-entry-${opts.id}`,
+      previous: getLatestJournalEntryId(),
+    };
+
+    if (! opts.noDate) {
+      if (! opts.time) {
+        const now = new Date();
+        opts.time = `${now.getHours()}:${now.getMinutes()} ${now.getHours() >= 12 ? 'pm' : 'am'}`;
+      }
+
+      if (! opts.location) {
+        opts.location = getCurrentLocationName();
+      }
+    }
+
+    makeJournalEntry(opts);
+
+    await dbSet('data', data);
+  }
+
+  onEvent('journal-entry', (entry) => {
+    if (entry && entry.getAttribute('data-entry-id') === previousEntryId) {
+      const existingEntry = document.querySelector(`.journalEntries .entry[data-entry-id="journal-entry-${opts.id}"]`);
+      if (existingEntry) {
+        return;
+      }
+
+      makeJournalEntry({
+        ...opts,
+        ...previousEntryData.data,
+        id: `journal-entry-${opts.id}`,
+        before: previousEntryId,
+      });
+    }
+  });
+};
+
+export {
+  replaceJournalEntry,
+  makeJournalEntry,
+  addJournalEntry
+};

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -10,6 +10,10 @@ const getCurrentLocation = () => {
   return location.toLowerCase();
 };
 
+const getCurrentLocationName = () => {
+  return user?.environment_name || getCurrentLocation();
+};
+
 /**
  * Ping https://rh-api.mouse.rip/ to get the current location of the Relic Hunter.
  *
@@ -55,6 +59,7 @@ const travelTo = (location) => {
 
 export {
   getCurrentLocation,
+  getCurrentLocationName,
   getRelicHunterLocation,
   travelTo
 };

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -1,4 +1,5 @@
 import { getHeaders, sessionGet, sessionSet } from './data';
+import { makeElement } from './elements';
 
 /**
  * Get the current location.
@@ -52,6 +53,16 @@ const getRelicHunterLocation = () => {
  * @param {string} location The location to travel to.
  */
 const travelTo = (location) => {
+  const header = document.querySelector('.mousehuntHeaderView');
+  if (header) {
+    const existing = header.querySelector('.mh-improved-travel-message');
+    if (existing) {
+      existing.remove();
+    }
+
+    makeElement('div', ['mh-improved-travel-message', 'travelPage-map-message'], 'Traveling...', header);
+  }
+
   if (app?.pages?.TravelPage?.travel) {
     app.pages.TravelPage.travel(location);
   }

--- a/src/utils/maps.js
+++ b/src/utils/maps.js
@@ -180,14 +180,14 @@ const showTravelConfirmationNoDetails = async (environment) => {
       id: environment.id,
       type: environment.id,
       thumb: environment.image,
-      header: environment.headerImage,
+      header: environment.header,
       goals: environment.goals || [],
       num_completed_goals: 0,
-      num_total_goals: environmentMice.length,
+      num_total_goals: 0,
       hunters: [],
       is_current_environment: getCurrentLocation() === environment.id,
       can_travel: true,
-      num_missing_goals: environmentMice.length,
+      num_missing_goals: 0,
     },
     goals: []
   };

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -1,8 +1,9 @@
 import { debug } from './debug';
 import { makeElement } from './elements';
 
+import errorPageStyles from './styles/page-error.css';
 import errorStyles from './styles/errors.css';
-import maintenanceStyles from './styles/maintenance.css';
+import maintenanceStyles from './styles/page-maintenance.css';
 
 /**
  * Show an error message appended to the given element.
@@ -113,12 +114,16 @@ const showLoadingError = (e) => {
 
 const maybeDoMaintenance = () => {
   const maintenance = document.querySelector('body.PageMaintenance');
-  if (! maintenance) {
-    return;
+  if (maintenance) {
+    const maintenanceStylesEl = makeElement('style', 'mh-improved-maintenance-styles', maintenanceStyles);
+    document.head.append(maintenanceStylesEl);
   }
 
-  const maintenanceStylesEl = makeElement('style', 'mh-improved-maintenance-styles', maintenanceStyles);
-  document.head.append(maintenanceStylesEl);
+  const errorPage = document.querySelector('body.PageLockError');
+  if (errorPage) {
+    const errorPageStylesEl = makeElement('style', 'mh-improved-error-page-styles', errorPageStyles);
+    document.head.append(errorPageStylesEl);
+  }
 };
 
 /**

--- a/src/utils/settings-markup.js
+++ b/src/utils/settings-markup.js
@@ -254,6 +254,13 @@ const makeSettingRowSelect = ({ key, tab, defaultValue, settingSettings }) => {
    * @return {Object} The option and whether or not it's selected.
    */
   const makeOption = (option, foundSelected, currentSetting, dValue, i) => {
+    if (option.seperator) {
+      return {
+        settingRowInputDropdownSelectOption: makeElement('hr'),
+        foundSelected,
+      };
+    }
+
     const settingRowInputDropdownSelectOption = document.createElement('option');
     settingRowInputDropdownSelectOption.value = option.value;
     settingRowInputDropdownSelectOption.textContent = option.name;

--- a/src/utils/styles/page-error.css
+++ b/src/utils/styles/page-error.css
@@ -1,0 +1,108 @@
+body.PageLockError .pageFrameView {
+  grid-template-rows: [page-start] auto [page-end];
+  grid-template-columns: [first] auto [content-start] 400px [content-end] auto [last];
+}
+
+body.PageLockError .pageFrameView-column.right {
+  background: #bad4ed url(https://www.mousehuntgame.com/images/ui/backgrounds/app_frame_right.gif) repeat-y 0% 0% !important;
+  border: none;
+}
+
+body.PageLockError .pageFrameView-column.left {
+  background: #bad4ed url(https://www.mousehuntgame.com/images/ui/backgrounds/app_frame_left.gif) repeat-y 100% 0% !important;
+  border: none;
+}
+
+body.PageLockError {
+  background: url(https://www.mousehuntgame.com/images/map/login-page/standard/1.jpg) no-repeat top center;
+}
+
+body.PageLockError .pageFrameView-content {
+  min-height: calc(80vh - 110px);
+  background: transparent;
+}
+
+body.PageLockError .pageFrameView-footer {
+  display: flex;
+  flex-flow: row wrap;
+  row-gap: 20px;
+  align-items: center;
+  justify-content: center;
+  background-color: rgb(255 255 255 / 70%);
+  transition: 0.3s;
+}
+
+body.PageLockError .pageFrameView-footer-linksContainer {
+  flex: 0 0 100%;
+}
+
+body.PageLockError .pageFrameView-footer a img {
+  opacity: 0.4;
+  transition: 0.3s;
+  transform: scale(0.8);
+}
+
+body.PageLockError .pageFrameView-footer-links.terms {
+  text-align: center;
+}
+
+body.PageLockError .pageFrameView-footer a:hover img {
+  opacity: 1;
+  transform: scale(1);
+}
+
+body.PageLockError .maintenanceMessage:hover::after {
+  transform: rotate(-3deg) scale(1.2);
+}
+
+body.PageLockError .pageFrameView-contentContainer {
+  background: none;
+}
+
+body.PageLockError .container {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+@media screen and (min-width: 501px) {
+  body.PageLockError .pageFrameView {
+    grid-template-columns: [first] auto [content-start] 500px [content-end] auto [last];
+  }
+}
+
+@media only screen and (min-width: 801px) {
+  body.PageLockError .pageFrameView {
+    grid-template-columns: [first] auto [content-start] 800px [content-end] auto [last];
+  }
+}
+
+@media only screen and (max-width: 810px) {
+  body.PageLockError.noSidebar .pageFrameView {
+    background: none !important;
+  }
+}
+
+div[style*="margin:12px 0px 12px 0px; padding:12px; border:1px solid #ccc;"] {
+  margin: 10px !important;
+  margin-top: 20vh !important;
+  background-color: rgb(255 255 255 / 85%);
+  border: 2px solid #000 !important;
+}
+
+div[style*="float:left"] {
+  width: 230px;
+  height: 230px;
+  background-image: url(https://i.mouse.rip/error-mouse.png);
+}
+
+div[style*="float:left"] img {
+  display: none;
+}
+
+div[style*="margin:24px 0px 0px 230px;"] {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  float: none;
+  height: 190px;
+}

--- a/src/utils/styles/page-error.css
+++ b/src/utils/styles/page-error.css
@@ -106,3 +106,11 @@ div[style*="margin:24px 0px 0px 230px;"] {
   float: none;
   height: 190px;
 }
+
+div[style*="float:left"]:hover {
+  transform: translateX(10px);
+}
+
+div[style*="float:left"]:active {
+  transform: translateX(20px);
+}

--- a/src/utils/styles/page-maintenance.css
+++ b/src/utils/styles/page-maintenance.css
@@ -28,7 +28,7 @@ body.PageMaintenance .pageFrameView-footer {
   row-gap: 20px;
   align-items: center;
   justify-content: center;
-  background-color: rgb(255 255 255 / 25%);
+  background-color: rgb(255 255 255 / 70%);
   transition: 0.3s;
 }
 


### PR DESCRIPTION
Closes #339 
Closes #338 
Closes #336


# Changelog

## Version 0.41.0

### New Features

- Added "Delayed Menus" experiment to delay the opening of menus
- Added "Legacy HUD Tweaks" experiment to tweak the Legacy HUD
- Added "Legacy HUD" experiment to enable either part or all of the Legacy HUD
- Added "Shield Goes to Camp" experiment which will update the shield to link to the camp unless you're already there
- Added "Sticky Popups" experiment to make popups/overlays sticky
- Added "Unique Loot Count" experiment to show the total and unique loot counts in your progress log

### Better Gifts

- Updated styles

### Better Inventory

- Added cap of 200 items being opened at once

### Better Journal

- Refactored journal processing for more stablility
- Fixed image duplication when viewing historical mouse catch entries
- Updated replacements
- Added new crown journal entry styles
- Update styles

### Better Maps

- Fixed issue with "Default to Sorted tab" not working
- Updated scroll shop tab to be easier to navigate
- Added ability to drag sticky mouse details popup out of map and keep it open
- Updated styles

### Better Send Supplies

- Updated styles

### Better Shops

- Added "Limit 1" to items that have an inventory limit	Updated styles

### Better Travel

- Fixed favorite buttons not showing
- Updated styles

### Better UI

- Added `no-kingdom-link-replacement` feature flag to disable kingdom link replacement
- Updated styles

### Experiments

- Added "Delayed Menus" experiment to delay the opening of menus
- Added "Legacy HUD Tweaks" experiment to tweak the Legacy HUD
- Added "Legacy HUD" experiment to enable either part or all of the Legacy HUD
- already there    Added "Sticky Popups" experiment to make popups/overlays sticky
- Added "Unique Loot Count" experiment to show the total and unique loot counts in your progress log
- Big Timer - Fixed issue with timer not showing
- Big Timer - Updated styles for Legacy HUD
- Journal Tags - Updated styles
- favicons

### Inventory Open all but One

- Added cap of 200 items being opened at once

### Location Dashboard

- Added ability to click on the location name to travel to the location
- Updates Bountiful Beanstalk display
- Updates Fiery Warpath display
- Updates Floating Islands display

### Location HUDs: Bountiful Beanstalk

- Removes room loot title change
- Updates crafting button amounts
- Updates styles

### Location HUDs: Fiery Warpath

- Fixed easter egg activation position and streak container styling

### Location HUDs: Floating Islands

- Style updates

### Location HUDs: Spring Egg Hunt

- Add ability to right-click on tile while playing Eggsweeper to mark with a flag
- Updated styles

### Quick Send Supplies

- Added seperator in options for clarity
- Updated styles

### Show Auras

- Updated styles

### Taller Windows

- Updated Airship customizer window to be full height
- Updated styles

### Other

- Updates error page styles
- Performance improvements and minor bug fixes
