### PR TITLE
Fix secrets (cache) value in VRift simulator

### DIFF
--- a/src/modules/location-huds/rift-valour/simulator.js
+++ b/src/modules/location-huds/rift-valour/simulator.js
@@ -534,7 +534,7 @@ function simulate(shouldDisplay = true) {
       lootSigils: Math.round(sigils),
       lootSecrets: Math.round(secrets),
       cacheSigils: deltaCache[0],
-      cacheSecrets: deltaCache[0],
+      cacheSecrets: deltaCache[1],
       eclipses,
     };
   }


### PR DESCRIPTION
Values should be identical across VRift sims, but MH improved secrets (cache) value looks to be the same as the sigils (cache) value.

<img width="239" alt="Screenshot 2024-05-04 at 6 28 21 PM" src="https://github.com/MHCommunity/mousehunt-improved/assets/86172063/0d8c404d-abe3-4a6c-9f8d-e0ce9d6b56b6">
<img width="426" alt="Screenshot 2024-05-04 at 6 28 27 PM" src="https://github.com/MHCommunity/mousehunt-improved/assets/86172063/b49e981d-0f58-4585-97df-203c16dd979b">
