### PR TITLE
HUD update for SoSo

### DIFF
--- a/src/modules/location-huds/school-of-sorcery/index.js
+++ b/src/modules/location-huds/school-of-sorcery/index.js
@@ -1,0 +1,10 @@
+import { addHudStyles } from '@utils';
+
+import styles from './styles.css';
+
+/**
+ * Initialize the module.
+ */
+export default async () => {
+  addHudStyles(styles);
+};

--- a/src/modules/location-huds/school-of-sorcery/styles.css
+++ b/src/modules/location-huds/school-of-sorcery/styles.css
@@ -1,0 +1,3 @@
+.folkloreForestRegionView-trapWarningContainer {
+  top: 40%
+}


### PR DESCRIPTION
Moves "no bait" warning down a bit to unblock the "Hunts Remaining" part of the HUD, to resolve #361 