### PR TITLE
add min height to the container to properly center the quill image

### DIFF
--- a/src/modules/better-journal/journal-styles/styles/custom-entries/location/folklore-forest.css
+++ b/src/modules/better-journal/journal-styles/styles/custom-entries/location/folklore-forest.css
@@ -11,9 +11,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 35px;
   background-color: #fff9ee;
   box-shadow: inset 0 0 9px -2px #a78f77;
+  min-height: 40px;
 }
 
 .journal .entry.folkloreForest-tableOfContents.wordCount .journaltext {

--- a/src/modules/better-journal/journal-styles/styles/custom-entries/location/folklore-forest.css
+++ b/src/modules/better-journal/journal-styles/styles/custom-entries/location/folklore-forest.css
@@ -11,9 +11,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 40px;
   background-color: #fff9ee;
   box-shadow: inset 0 0 9px -2px #a78f77;
-  min-height: 40px;
 }
 
 .journal .entry.folkloreForest-tableOfContents.wordCount .journaltext {


### PR DESCRIPTION
Quill icon is close the bottom of the container:
![image](https://github.com/MHCommunity/mousehunt-improved/assets/3811554/1f35bad1-0211-422e-8f8a-c590b18f3244)

Added min height to "properly" center the icon:
![image](https://github.com/MHCommunity/mousehunt-improved/assets/3811554/d2a241b3-338c-4213-a011-6957ea640934)
