### PR TITLE
Remove min-width for hunterInfoView-idCardTooltipBox-content

### DIFF
--- a/src/modules/better-ui/styles/general.css
+++ b/src/modules/better-ui/styles/general.css
@@ -294,7 +294,6 @@ a.trapImageView-zoomButton {
 
 /* team hover */
 .hunterInfoView-idCardTooltipBox-content {
-  min-width: 80px;
   text-align: center;
 }
 


### PR DESCRIPTION
Hover tooltips on the profile page have some extra padding on the right when the text length is too short, I searched and found this min-width to be the cause, however I am not sure of the original reason to include this change (it looks it was for the team hover tooltip). Removing min-width didn't seem to affect anything when I looked at my team's hover tooltip, so I removed it here, but if there is some change or reason I don't know about, feel free to decline the change.

<img width="95" alt="Screenshot 2024-05-20 at 2 09 58 AM" src="https://github.com/MHCommunity/mousehunt-improved/assets/86172063/a3ae0003-cc7b-4cb2-8bcb-d5f1cd756692">
