### PR TITLE
Prevent redundant hit of treasuremap.php

### DIFF
--- a/src/modules/better-maps/modules/sidebar.js
+++ b/src/modules/better-maps/modules/sidebar.js
@@ -123,6 +123,10 @@ const addMapToSidebar = async () => {
 const refreshMap = async () => {
   const mapId = user?.quests?.QuestRelicHunter?.default_map_id || false;
 
+  if (! mapId) {
+    return false;
+  }
+
   let newMapData;
   try {
     newMapData = await doRequest('managers/ajax/users/treasuremap.php', {


### PR DESCRIPTION
If the user is not on any treasure map, the quest QuestRelicHunter.default_map_id will be null. Hitting the treasure map endpoint with null as the map_id returns an error in the messageData.popup response.

It's not shown to the user but it's still best to not do extraneous network requests to HG servers.
