### PR TITLE
Remove dupe of crazed_cultivator in fofo maps

### DIFF
--- a/src/data/map-groups.json
+++ b/src/data/map-groups.json
@@ -268,7 +268,6 @@
         "color": "#d7b18b",
         "mice": [
           "angry_aphid",
-          "crazed_cultivator",
           "grit_grifter",
           "mighty_mite",
           "root_rummager",
@@ -361,7 +360,6 @@
           "angry_aphid",
           "root_rummager",
           "grit_grifter",
-          "crazed_cultivator",
           "mighty_mite",
           "wily_weevil",
           {


### PR DESCRIPTION
Crazed Cultivator mouse is only attracted to SB so it belongs in its own SB section, which is there, but because crazed_cultivator is referenced twice it does not show up properly.
<img width="236" alt="Screenshot 2024-07-01 at 1 57 55 AM" src="https://github.com/MHCommunity/mousehunt-improved/assets/86172063/fe3af6c3-72d6-43f7-b4df-6e14c850fd2e">
