### PR TITLE
Fix Key Master group in BB maps

### DIFF
--- a/src/data/map-groups.json
+++ b/src/data/map-groups.json
@@ -2231,7 +2231,7 @@
           },
           {
             "mouse": "key_master",
-            "subcategory": "royal"
+            "subcategory": "lavish"
           },
           {
             "mouse": "wrathful_warden",


### PR DESCRIPTION
Key Master is attracted to Lavish Beanster, not Royal Beanster.