### PR TITLE
Fix foreword farm plant types

### DIFF
--- a/src/modules/location-dashboard/locations/foreword-farm.js
+++ b/src/modules/location-dashboard/locations/foreword-farm.js
@@ -9,13 +9,14 @@ export default (quests) => {
   if (! quests.QuestForewordFarm) {
     return '';
   }
+  const recipes = user.enviroment_atts?.recipes || [];
+  const plants = recipes.reduce((acc, recipe) => {
+    if (recipe.type) {
+      acc[recipe.type] = 0;
+    }
 
-  const plants = {
-    empty: 0,
-    ordinary_farm_plant: 0,
-    legendary_farm_plant: 0,
-    twisted_legendary_magic_farm_plant: 0,
-  };
+    return acc;
+  }, {});
 
   quests.QuestForewordFarm.plots.forEach((plot) => {
     const name = plot.is_growing ? plot.plant.type : 'empty';
@@ -27,20 +28,18 @@ export default (quests) => {
   }
 
   let returnText = '';
-  if (plants.ordinary_farm_plant > 0) {
-    returnText += `${plants.ordinary_farm_plant} Mulch, `;
-  }
 
-  if (plants.legendary_farm_plant > 0) {
-    returnText += `${plants.legendary_farm_plant} Papyrus, `;
-  }
-
-  if (plants.twisted_legendary_magic_farm_plant > 0) {
-    returnText += `${plants.twisted_legendary_magic_farm_plant} Twisted Papyrus, `;
-  }
+  Object.entries(plants).forEach(([type, count]) => {
+    if (count > 0) {
+      const recipeName = recipes.find(recipe => recipe.type === type)?.name;
+      if (recipeName) {
+        returnText += `${count} ${recipeName}, `;
+      }
+    }
+  });
 
   // remove trailing comma
-  returnText = returnText.slice(0, -2);
+  returnText = returnText.trim().replace(/,$/, '');
 
   return `Growing ${returnText}`;
 };

--- a/src/modules/location-dashboard/locations/foreword-farm.js
+++ b/src/modules/location-dashboard/locations/foreword-farm.js
@@ -31,7 +31,7 @@ export default (quests) => {
 
   Object.entries(plants).forEach(([type, count]) => {
     if (count > 0) {
-      const recipeName = recipes.find(recipe => recipe.type === type)?.name;
+      const recipeName = recipes.find((recipe) => recipe.type === type)?.name;
       if (recipeName) {
         returnText += `${count} ${recipeName}, `;
       }


### PR DESCRIPTION
Fix plant counting for all types by simplifying plant counting using recipe types and counts from user environment attributes. Streamlined the text generation process to use recipe names directly, reducing hardcoded type dependencies.

![Screenshot 2024-12-26 130105](https://github.com/user-attachments/assets/12d64054-f1a4-4d39-841d-a77d186dab39)
