### PR TITLE
Adjust margin for vending machine purchase entries

### DIFF
--- a/src/modules/better-journal/modules/journal-styles/styles/custom-entries/location/birthday.css
+++ b/src/modules/better-journal/modules/journal-styles/styles/custom-entries/location/birthday.css
@@ -29,7 +29,7 @@
 }
 
 .journal .content .entry.vending_machine_purchase .journaltext {
-  margin-top: 16px;
+  margin-top: -5px;
   font-size: 10px;
   font-weight: 900;
   line-height: 12px;


### PR DESCRIPTION
### Description
This pull request adjusts the `margin-top` value in the CSS for vending machine purchase journal entries. 

**Before:**
![before](https://github.com/user-attachments/assets/76970ee5-6669-44e6-8dcd-40ec2cfd940b)

**After:** 
![after](https://github.com/user-attachments/assets/08ded079-c427-4af7-866e-c6f11d340407)